### PR TITLE
Add devicePixelRatio property to QPaintedTextureImage

### DIFF
--- a/src/render/texture/qpaintedtextureimage.h
+++ b/src/render/texture/qpaintedtextureimage.h
@@ -56,6 +56,7 @@ class QT3DRENDERSHARED_EXPORT QPaintedTextureImage : public QAbstractTextureImag
     Q_PROPERTY(int width READ width WRITE setWidth NOTIFY widthChanged)
     Q_PROPERTY(int height READ height WRITE setHeight NOTIFY heightChanged)
     Q_PROPERTY(QSize size READ size WRITE setSize NOTIFY sizeChanged)
+    Q_PROPERTY(qreal devicePixelRatio READ devicePixelRatio WRITE setDevicePixelRatio NOTIFY devicePixelRatioChanged)
 
 public:
     explicit QPaintedTextureImage(Qt3DCore::QNode *parent = nullptr);
@@ -64,6 +65,7 @@ public:
     int width() const;
     int height() const;
     QSize size() const;
+    qreal devicePixelRatio() const;
 
     void update(const QRect &rect = QRect());
 
@@ -71,11 +73,13 @@ public Q_SLOTS:
     void setWidth(int w);
     void setHeight(int h);
     void setSize(QSize size);
+    void setDevicePixelRatio(qreal scaleFactor);
 
 Q_SIGNALS:
     void widthChanged(int w);
     void heightChanged(int w);
     void sizeChanged(QSize size);
+    void devicePixelRatioChanged(qreal scaleFactor);
 
 protected:
     virtual void paint(QPainter *painter) = 0;

--- a/src/render/texture/qpaintedtextureimage_p.h
+++ b/src/render/texture/qpaintedtextureimage_p.h
@@ -72,6 +72,7 @@ public:
     Q_DECLARE_PUBLIC(QPaintedTextureImage)
 
     QSize m_imageSize;
+    qreal m_devicePixelRatio;
     QScopedPointer<QImage> m_image;
     QTextureImageDataGeneratorPtr m_currentGenerator;
 


### PR DESCRIPTION
[ChangeLog] Added a devicePixelRatio property for QPaintedTextureImage.

Task-number: QTBUG-68718
Change-Id: I01b0ceb4ad1a5a7f27c7335a91a25cd39e9a28cd