### PR TITLE
Move classes in OpenGL renderer plugin into an OpenGL namespace

### DIFF
--- a/src/plugins/renderers/opengl/graphicshelpers/graphicscontext.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicscontext.cpp
@@ -112,6 +112,7 @@ QOpenGLShader::ShaderType shaderType(Qt3DRender::QShaderProgram::ShaderType type
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 namespace {
 
@@ -966,6 +967,7 @@ QT3D_UNIFORM_TYPE_IMPL(UniformType::Mat4x2, float, glUniformMatrix4x2fv)
 QT3D_UNIFORM_TYPE_IMPL(UniformType::Mat3x4, float, glUniformMatrix3x4fv)
 QT3D_UNIFORM_TYPE_IMPL(UniformType::Mat4x3, float, glUniformMatrix4x3fv)
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender of namespace
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicscontext_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicscontext_p.h
@@ -38,8 +38,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSCONTEXT_H
-#define QT3DRENDER_RENDER_GRAPHICSCONTEXT_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSCONTEXT_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSCONTEXT_H
 
 //
 //  W A R N I N G
@@ -85,10 +85,13 @@ namespace Qt3DRender {
 
 namespace Render {
 
-class GraphicsHelperInterface;
 class RenderTarget;
 class AttachmentPack;
 class ShaderManager;
+
+namespace OpenGL {
+
+class GraphicsHelperInterface;
 class GLShader;
 class GLShaderManager;
 
@@ -250,9 +253,10 @@ QT3D_UNIFORM_TYPE_PROTO(UniformType::Mat4x2, float, glUniformMatrix4x2fv)
 QT3D_UNIFORM_TYPE_PROTO(UniformType::Mat3x4, float, glUniformMatrix3x4fv)
 QT3D_UNIFORM_TYPE_PROTO(UniformType::Mat4x3, float, glUniformMatrix4x3fv)
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GRAPHICSCONTEXT_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSCONTEXT_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes2.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes2.cpp
@@ -38,11 +38,12 @@
 ****************************************************************************/
 
 #include "graphicshelperes2_p.h"
-#include <Qt3DRender/private/renderlogging_p.h>
 #include <private/attachmentpack_p.h>
 #include <qgraphicsutils_p.h>
 #include <renderbuffer_p.h>
+#include <logging_p.h>
 #include <QtGui/private/qopenglextensions_p.h>
+
 
 QT_BEGIN_NAMESPACE
 
@@ -65,6 +66,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 GraphicsHelperES2::GraphicsHelperES2()
     : m_funcs(0)
@@ -273,7 +275,7 @@ void GraphicsHelperES2::vertexAttributePointer(GLenum shaderDataType,
         break;
 
     default:
-        qCWarning(Render::Rendering) << "vertexAttribPointer: Unhandled type";
+        qCWarning(Rendering) << "vertexAttribPointer: Unhandled type";
         Q_UNREACHABLE();
     }
 }
@@ -317,7 +319,7 @@ void GraphicsHelperES2::blendFuncSeparatei(GLuint buf, GLenum sRGB, GLenum dRGB,
 
 void GraphicsHelperES2::alphaTest(GLenum, GLenum)
 {
-    qCWarning(Render::Rendering) << Q_FUNC_INFO << "AlphaTest not available with OpenGL ES 2.0";
+    qCWarning(Rendering) << Q_FUNC_INFO << "AlphaTest not available with OpenGL ES 2.0";
 }
 
 void GraphicsHelperES2::depthTest(GLenum mode)
@@ -833,6 +835,7 @@ void GraphicsHelperES2::blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, G
         m_ext->glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes2_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes2_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERES2_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERES2_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES2_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES2_H
 
 //
 //  W A R N I N G
@@ -61,6 +61,7 @@ class QOpenGLExtensions;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class GraphicsHelperES2 : public GraphicsHelperInterface
 {
@@ -165,9 +166,10 @@ protected:
     QScopedPointer<QOpenGLExtensions> m_ext;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERES2_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES2_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3.cpp
@@ -41,7 +41,7 @@
 #include "graphicshelperes3_p.h"
 #include <private/attachmentpack_p.h>
 #include <qgraphicsutils_p.h>
-#include <private/renderlogging_p.h>
+#include <logging_p.h>
 #include <QOpenGLExtraFunctions>
 
 QT_BEGIN_NAMESPACE
@@ -149,6 +149,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 GraphicsHelperES3::GraphicsHelperES3()
 {
@@ -229,7 +230,7 @@ void GraphicsHelperES3::vertexAttributePointer(GLenum shaderDataType,
         break;
 
     default:
-        qCWarning(Render::Rendering) << "vertexAttribPointer: Unhandled type";
+        qCWarning(Rendering) << "vertexAttribPointer: Unhandled type";
         Q_UNREACHABLE();
     }
 }
@@ -570,7 +571,7 @@ QVector<ShaderUniform> GraphicsHelperES3::programUniformsAndLocations(GLuint pro
         m_extraFuncs->glGetActiveUniformsiv(programId, 1, (GLuint*)&i, GL_UNIFORM_MATRIX_STRIDE, &uniform.m_matrixStride);
         uniform.m_rawByteSize = uniformByteSize(uniform);
         uniforms.append(uniform);
-        qCDebug(Render::Rendering) << uniform.m_name << "size" << uniform.m_size
+        qCDebug(Rendering) << uniform.m_name << "size" << uniform.m_size
                                    << " offset" << uniform.m_offset
                                    << " rawSize" << uniform.m_rawByteSize;
     }
@@ -599,6 +600,7 @@ QVector<ShaderUniformBlock> GraphicsHelperES3::programUniformBlocks(GLuint progr
     return blocks;
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3_2.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3_2.cpp
@@ -54,6 +54,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 GraphicsHelperES3_2::GraphicsHelperES3_2()
 {
@@ -97,6 +98,7 @@ void GraphicsHelperES3_2::bindFrameBufferAttachment(QOpenGLTexture *texture, con
     texture->release();
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3_2_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3_2_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERES3_2_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERES3_2_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES3_2_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES3_2_H
 
 //
 //  W A R N I N G
@@ -57,6 +57,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class GraphicsHelperES3_2 : public GraphicsHelperES3
 {
@@ -69,9 +70,10 @@ public:
     bool frameBufferNeedsRenderBuffer(const Attachment &attachment) override;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERES3_2_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES3_2_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelperes3_p.h
@@ -38,8 +38,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERES3_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERES3_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES3_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES3_H
 
 //
 //  W A R N I N G
@@ -58,6 +58,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class GraphicsHelperES3 : public GraphicsHelperES2
 {
@@ -92,9 +93,10 @@ protected:
     QOpenGLExtraFunctions *m_extraFuncs = nullptr;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERES3_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERES3_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl2.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl2.cpp
@@ -43,12 +43,13 @@
 #include <private/attachmentpack_p.h>
 #include <QtOpenGLExtensions/QOpenGLExtensions>
 #include <qgraphicsutils_p.h>
-#include <Qt3DRender/private/renderlogging_p.h>
+#include <logging_p.h>
 
 QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 GraphicsHelperGL2::GraphicsHelperGL2()
     : m_funcs(nullptr)
@@ -257,7 +258,7 @@ void GraphicsHelperGL2::vertexAttributePointer(GLenum shaderDataType,
         break;
 
     default:
-        qCWarning(Render::Rendering) << "vertexAttribPointer: Unhandled type";
+        qCWarning(Rendering) << "vertexAttribPointer: Unhandled type";
         Q_UNREACHABLE();
     }
 }
@@ -874,6 +875,7 @@ void GraphicsHelperGL2::blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, G
     qWarning() << "Framebuffer blits are not supported by ES 2.0 (since ES 3.1)";
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl2_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl2_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERGL2_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERGL2_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL2_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL2_H
 
 //
 //  W A R N I N G
@@ -63,6 +63,7 @@ class QOpenGLExtension_ARB_framebuffer_object;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class OPENGL_RENDERER_EXPORT GraphicsHelperGL2 : public GraphicsHelperInterface
 {
@@ -165,6 +166,7 @@ private:
     QOpenGLExtension_ARB_framebuffer_object *m_fboFuncs;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
@@ -172,4 +174,4 @@ QT_END_NAMESPACE
 
 #endif // !QT_OPENGL_ES_2
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERGL2_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL2_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_2.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_2.cpp
@@ -43,8 +43,8 @@
 #include <QOpenGLFunctions_3_2_Core>
 #include <QOpenGLFunctions_3_3_Core>
 #include <QtOpenGLExtensions/qopenglextensions.h>
-#include <Qt3DRender/private/renderlogging_p.h>
 #include <private/attachmentpack_p.h>
+#include <logging_p.h>
 #include <qgraphicsutils_p.h>
 
 QT_BEGIN_NAMESPACE
@@ -70,6 +70,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 GraphicsHelperGL3_2::GraphicsHelperGL3_2()
     : m_funcs(nullptr)
@@ -216,9 +217,9 @@ QVector<ShaderUniform> GraphicsHelperGL3_2::programUniformsAndLocations(GLuint p
         m_funcs->glGetActiveUniformsiv(programId, 1, (GLuint*)&i, GL_UNIFORM_MATRIX_STRIDE, &uniform.m_matrixStride);
         uniform.m_rawByteSize = uniformByteSize(uniform);
         uniforms.append(uniform);
-        qCDebug(Render::Rendering) << uniform.m_name << "size" << uniform.m_size
-                                   << " offset" << uniform.m_offset
-                                   << " rawSize" << uniform.m_rawByteSize;
+        qCDebug(Rendering) << uniform.m_name << "size" << uniform.m_size
+                           << " offset" << uniform.m_offset
+                           << " rawSize" << uniform.m_rawByteSize;
     }
 
     return uniforms;
@@ -279,7 +280,7 @@ void GraphicsHelperGL3_2::vertexAttribDivisor(GLuint index, GLuint divisor)
 {
     Q_UNUSED(index);
     Q_UNUSED(divisor);
-    qCWarning(Render::Rendering) << "Vertex attribute divisor not available with OpenGL 3.2 core";
+    qCWarning(Rendering) << "Vertex attribute divisor not available with OpenGL 3.2 core";
 }
 
 void GraphicsHelperGL3_2::vertexAttributePointer(GLenum shaderDataType,
@@ -319,7 +320,7 @@ void GraphicsHelperGL3_2::vertexAttributePointer(GLenum shaderDataType,
         break;
 
     default:
-        qCWarning(Render::Rendering) << "vertexAttribPointer: Unhandled type";
+        qCWarning(Rendering) << "vertexAttribPointer: Unhandled type";
         Q_UNREACHABLE();
     }
 }
@@ -361,7 +362,7 @@ void GraphicsHelperGL3_2::blendFuncSeparatei(GLuint buf, GLenum sRGB, GLenum dRG
 
 void GraphicsHelperGL3_2::alphaTest(GLenum, GLenum)
 {
-    qCWarning(Render::Rendering) << "AlphaTest not available with OpenGL 3.2 core";
+    qCWarning(Rendering) << "AlphaTest not available with OpenGL 3.2 core";
 }
 
 void GraphicsHelperGL3_2::depthTest(GLenum mode)
@@ -1180,6 +1181,7 @@ void GraphicsHelperGL3_2::blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1,
     m_funcs->glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_2_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_2_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERGL3_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERGL3_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL3_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL3_H
 
 //
 //  W A R N I N G
@@ -64,6 +64,7 @@ class QOpenGLExtension_ARB_tessellation_shader;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class OPENGL_RENDERER_EXPORT GraphicsHelperGL3_2 : public GraphicsHelperInterface
 {
@@ -167,6 +168,7 @@ private:
     QScopedPointer<QOpenGLExtension_ARB_tessellation_shader> m_tessFuncs;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
@@ -174,4 +176,4 @@ QT_END_NAMESPACE
 
 #endif // !QT_OPENGL_ES_2
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERGL3_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL3_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_3.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_3.cpp
@@ -42,8 +42,8 @@
 #ifndef QT_OPENGL_ES_2
 #include <QOpenGLFunctions_3_3_Core>
 #include <QtOpenGLExtensions/qopenglextensions.h>
-#include <Qt3DRender/private/renderlogging_p.h>
 #include <private/attachmentpack_p.h>
+#include <logging_p.h>
 #include <qgraphicsutils_p.h>
 
 # ifndef QT_OPENGL_3_2
@@ -69,6 +69,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 GraphicsHelperGL3_3::GraphicsHelperGL3_3()
     : m_funcs(nullptr)
@@ -215,9 +216,9 @@ QVector<ShaderUniform> GraphicsHelperGL3_3::programUniformsAndLocations(GLuint p
         m_funcs->glGetActiveUniformsiv(programId, 1, (GLuint*)&i, GL_UNIFORM_MATRIX_STRIDE, &uniform.m_matrixStride);
         uniform.m_rawByteSize = uniformByteSize(uniform);
         uniforms.append(uniform);
-        qCDebug(Render::Rendering) << uniform.m_name << "size" << uniform.m_size
-                                   << " offset" << uniform.m_offset
-                                   << " rawSize" << uniform.m_rawByteSize;
+        qCDebug(Rendering) << uniform.m_name << "size" << uniform.m_size
+                           << " offset" << uniform.m_offset
+                           << " rawSize" << uniform.m_rawByteSize;
     }
 
     return uniforms;
@@ -316,7 +317,7 @@ void GraphicsHelperGL3_3::vertexAttributePointer(GLenum shaderDataType,
         break;
 
     default:
-        qCWarning(Render::Rendering) << "vertexAttribPointer: Unhandled type";
+        qCWarning(Rendering) << "vertexAttribPointer: Unhandled type";
     }
 }
 
@@ -357,7 +358,7 @@ void GraphicsHelperGL3_3::blendFuncSeparatei(GLuint buf, GLenum sRGB, GLenum dRG
 
 void GraphicsHelperGL3_3::alphaTest(GLenum, GLenum)
 {
-    qCWarning(Render::Rendering) << "AlphaTest not available with OpenGL 3.2 core";
+    qCWarning(Rendering) << "AlphaTest not available with OpenGL 3.2 core";
 }
 
 void GraphicsHelperGL3_3::depthTest(GLenum mode)
@@ -1176,6 +1177,7 @@ void GraphicsHelperGL3_3::blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1,
     m_funcs->glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_3_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl3_3_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERGL3_3_P_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERGL3_3_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL3_3_P_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL3_3_P_H
 
 //
 //  W A R N I N G
@@ -63,6 +63,7 @@ class QOpenGLExtension_ARB_tessellation_shader;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class OPENGL_RENDERER_EXPORT GraphicsHelperGL3_3 : public GraphicsHelperInterface
 {
@@ -166,6 +167,7 @@ private:
     QScopedPointer<QOpenGLExtension_ARB_tessellation_shader> m_tessFuncs;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
@@ -173,4 +175,4 @@ QT_END_NAMESPACE
 
 #endif // !QT_OPENGL_ES_2
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERGL3_3_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL3_3_P_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl4.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl4.cpp
@@ -42,9 +42,9 @@
 #ifndef QT_OPENGL_ES_2
 #include <QOpenGLFunctions_4_3_Core>
 #include <QtOpenGLExtensions/qopenglextensions.h>
-#include <Qt3DRender/private/renderlogging_p.h>
 #include <private/attachmentpack_p.h>
 #include <qgraphicsutils_p.h>
+#include <logging_p.h>
 
 # ifndef QT_OPENGL_4_3
 #  ifndef GL_PATCH_VERTICES
@@ -85,6 +85,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 namespace {
 
@@ -258,9 +259,9 @@ QVector<ShaderUniform> GraphicsHelperGL4::programUniformsAndLocations(GLuint pro
         m_funcs->glGetActiveUniformsiv(programId, 1, (GLuint*)&i, GL_UNIFORM_MATRIX_STRIDE, &uniform.m_matrixStride);
         uniform.m_rawByteSize = uniformByteSize(uniform);
         uniforms.append(uniform);
-        qCDebug(Render::Rendering) << uniform.m_name << "size" << uniform.m_size
-                                   << " offset" << uniform.m_offset
-                                   << " rawSize" << uniform.m_rawByteSize;
+        qCDebug(Rendering) << uniform.m_name << "size" << uniform.m_size
+                           << " offset" << uniform.m_offset
+                           << " rawSize" << uniform.m_rawByteSize;
     }
 
     return uniforms;
@@ -385,7 +386,7 @@ void GraphicsHelperGL4::vertexAttributePointer(GLenum shaderDataType,
         break;
 
     default:
-        qCWarning(Render::Rendering) << "vertexAttribPointer: Unhandled type";
+        qCWarning(Rendering) << "vertexAttribPointer: Unhandled type";
         Q_UNREACHABLE();
     }
 }
@@ -621,7 +622,7 @@ void GraphicsHelperGL4::blendFuncSeparatei(GLuint buf, GLenum sRGB, GLenum dRGB,
 
 void GraphicsHelperGL4::alphaTest(GLenum, GLenum)
 {
-    qCWarning(Render::Rendering) << "AlphaTest not available with OpenGL 3.2 core";
+    qCWarning(Rendering) << "AlphaTest not available with OpenGL 3.2 core";
 }
 
 void GraphicsHelperGL4::depthTest(GLenum mode)
@@ -1234,6 +1235,7 @@ void GraphicsHelperGL4::blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, G
     m_funcs->glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl4_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelpergl4_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERGL4_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERGL4_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL4_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL4_H
 
 //
 //  W A R N I N G
@@ -63,6 +63,7 @@ class QOpenGLFunctions_4_3_Core;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class OPENGL_RENDERER_EXPORT GraphicsHelperGL4 : public GraphicsHelperInterface
 {
@@ -164,6 +165,7 @@ private:
     QOpenGLFunctions_4_3_Core *m_funcs;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
@@ -171,4 +173,4 @@ QT_END_NAMESPACE
 
 #endif // !QT_OPENGL_ES_2
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERGL4_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERGL4_H

--- a/src/plugins/renderers/opengl/graphicshelpers/graphicshelperinterface_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/graphicshelperinterface_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GRAPHICSHELPERINTERFACE_H
-#define QT3DRENDER_RENDER_GRAPHICSHELPERINTERFACE_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERINTERFACE_H
+#define QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERINTERFACE_H
 
 //
 //  W A R N I N G
@@ -64,6 +64,9 @@ namespace Qt3DRender {
 namespace Render {
 
 struct Attachment;
+
+namespace OpenGL {
+
 class RenderBuffer;
 
 class GraphicsHelperInterface
@@ -183,10 +186,10 @@ public:
     virtual UniformType uniformTypeFromGLType(GLenum glType) = 0;
 };
 
-
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GRAPHICSHELPERINTERFACE_H
+#endif // QT3DRENDER_RENDER_OPENGL_GRAPHICSHELPERINTERFACE_H

--- a/src/plugins/renderers/opengl/graphicshelpers/qgraphicsutils_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/qgraphicsutils_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_QGRAPHICSUTILS_P_H
-#define QT3DRENDER_RENDER_QGRAPHICSUTILS_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_QGRAPHICSUTILS_P_H
+#define QT3DRENDER_RENDER_OPENGL_QGRAPHICSUTILS_P_H
 
 //
 //  W A R N I N G
@@ -66,6 +66,8 @@ QT_BEGIN_NAMESPACE
 namespace Qt3DRender {
 
 namespace Render {
+
+namespace OpenGL {
 
 namespace {
 
@@ -401,10 +403,12 @@ public:
 
 };
 
+} // namespace OpenGL
+
 } // namespace Render
 
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_QGRAPHICSUTILS_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_QGRAPHICSUTILS_P_H

--- a/src/plugins/renderers/opengl/graphicshelpers/submissioncontext.cpp
+++ b/src/plugins/renderers/opengl/graphicshelpers/submissioncontext.cpp
@@ -96,6 +96,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 static QHash<unsigned int, SubmissionContext*> static_contexts;
 
@@ -1424,7 +1425,7 @@ HGLBuffer SubmissionContext::createGLBufferFor(Buffer *buffer)
     //    b.setUsagePattern(static_cast<QOpenGLBuffer::UsagePattern>(buffer->usage()));
     Q_ASSERT(b);
     if (!b->create(this))
-        qCWarning(Render::Io) << Q_FUNC_INFO << "buffer creation failed";
+        qCWarning(Io) << Q_FUNC_INFO << "buffer creation failed";
 
     return m_renderer->glResourceManagers()->glBufferManager()->lookupHandle(buffer->peerId());
 }
@@ -1445,7 +1446,7 @@ bool SubmissionContext::bindGLBuffer(GLBuffer *buffer, GLBuffer::Type type)
 void SubmissionContext::uploadDataToGLBuffer(Buffer *buffer, GLBuffer *b, bool releaseBuffer)
 {
     if (!bindGLBuffer(b, GLBuffer::ArrayBuffer)) // We're uploading, the type doesn't matter here
-        qCWarning(Render::Io) << Q_FUNC_INFO << "buffer bind failed";
+        qCWarning(Io) << Q_FUNC_INFO << "buffer bind failed";
     // If the buffer is dirty (hence being called here)
     // there are two possible cases
     // * setData was called changing the whole data or functor (or the usage pattern)
@@ -1488,13 +1489,13 @@ void SubmissionContext::uploadDataToGLBuffer(Buffer *buffer, GLBuffer *b, bool r
         b->release(this);
         m_boundArrayBuffer = nullptr;
     }
-    qCDebug(Render::Io) << "uploaded buffer size=" << buffer->data().size();
+    qCDebug(Io) << "uploaded buffer size=" << buffer->data().size();
 }
 
 QByteArray SubmissionContext::downloadDataFromGLBuffer(Buffer *buffer, GLBuffer *b)
 {
     if (!bindGLBuffer(b, GLBuffer::ArrayBuffer)) // We're downloading, the type doesn't matter here
-        qCWarning(Render::Io) << Q_FUNC_INFO << "buffer bind failed";
+        qCWarning(Io) << Q_FUNC_INFO << "buffer bind failed";
 
     QByteArray data = b->download(this, buffer->data().size());
     return data;
@@ -1576,6 +1577,7 @@ void SubmissionContext::blitFramebuffer(Qt3DCore::QNodeId inputRenderTargetId,
     bindFramebuffer(lastDrawFboId, GraphicsHelperInterface::FBOReadAndDraw);
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender of namespace
 

--- a/src/plugins/renderers/opengl/graphicshelpers/submissioncontext_p.h
+++ b/src/plugins/renderers/opengl/graphicshelpers/submissioncontext_p.h
@@ -38,8 +38,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_SUBMISSIONCONTEXT_H
-#define QT3DRENDER_RENDER_SUBMISSIONCONTEXT_H
+#ifndef QT3DRENDER_RENDER_OPENGL_SUBMISSIONCONTEXT_H
+#define QT3DRENDER_RENDER_OPENGL_SUBMISSIONCONTEXT_H
 
 //
 //  W A R N I N G
@@ -68,18 +68,21 @@ namespace Qt3DRender {
 
 namespace Render {
 
-class Renderer;
-class GraphicsHelperInterface;
-class RenderStateSet;
 class Material;
-class GLTexture;
-class RenderCommand;
-class RenderTarget;
 class AttachmentPack;
 class Attribute;
 class Buffer;
 class ShaderManager;
 struct StateVariant;
+class RenderTarget;
+class RenderStateSet;
+
+namespace OpenGL {
+
+class Renderer;
+class GraphicsHelperInterface;
+class GLTexture;
+class RenderCommand;
 
 enum TextureScope
 {
@@ -246,9 +249,10 @@ private:
     void disableAttribute(const VAOVertexAttribute &attr);
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_SUBMISSIONCONTEXT_H
+#endif // QT3DRENDER_RENDER_OPENGL_SUBMISSIONCONTEXT_H

--- a/src/plugins/renderers/opengl/io/glbuffer.cpp
+++ b/src/plugins/renderers/opengl/io/glbuffer.cpp
@@ -68,6 +68,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 // A UBO is created for each ShaderData Shader Pair
 // That means a UBO is unique to a shader/shaderdata
 
@@ -161,6 +163,8 @@ void GLBuffer::bindBufferBase(GraphicsContext *ctx, int bindingPoint)
 {
     ctx->bindBufferBase(m_lastTarget, bindingPoint, m_bufferId);
 }
+
+} // namespace OpenGL
 
 } // namespace Render
 

--- a/src/plugins/renderers/opengl/io/glbuffer_p.h
+++ b/src/plugins/renderers/opengl/io/glbuffer_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GLBUFFER_P_H
-#define QT3DRENDER_RENDER_GLBUFFER_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GLBUFFER_P_H
+#define QT3DRENDER_RENDER_OPENGL_GLBUFFER_P_H
 
 //
 //  W A R N I N G
@@ -60,6 +60,8 @@ QT_BEGIN_NAMESPACE
 namespace Qt3DRender {
 
 namespace Render {
+
+namespace OpenGL {
 
 class GraphicsContext;
 
@@ -101,10 +103,12 @@ private:
     GLenum m_lastTarget;
 };
 
+} // namespace OpenGL
+
 } // namespace Render
 
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GLBUFFER_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_GLBUFFER_P_H

--- a/src/plugins/renderers/opengl/jobs/filtercompatibletechniquejob.cpp
+++ b/src/plugins/renderers/opengl/jobs/filtercompatibletechniquejob.cpp
@@ -48,6 +48,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 FilterCompatibleTechniqueJob::FilterCompatibleTechniqueJob()
     : m_manager(nullptr)
@@ -89,6 +90,7 @@ void FilterCompatibleTechniqueJob::run()
     }
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/jobs/filtercompatibletechniquejob_p.h
+++ b/src/plugins/renderers/opengl/jobs/filtercompatibletechniquejob_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_FILTERCOMPATIBLETECHNIQUEJOB_H
-#define QT3DRENDER_RENDER_FILTERCOMPATIBLETECHNIQUEJOB_H
+#ifndef QT3DRENDER_RENDER_OPENGL_FILTERCOMPATIBLETECHNIQUEJOB_H
+#define QT3DRENDER_RENDER_OPENGL_FILTERCOMPATIBLETECHNIQUEJOB_H
 
 //
 //  W A R N I N G
@@ -62,6 +62,9 @@ namespace Qt3DRender {
 namespace Render {
 
 class TechniqueManager;
+
+namespace OpenGL {
+
 class Renderer;
 
 class OPENGL_RENDERER_EXPORT FilterCompatibleTechniqueJob : public Qt3DCore::QAspectJob
@@ -84,9 +87,10 @@ private:
 
 typedef QSharedPointer<FilterCompatibleTechniqueJob> FilterCompatibleTechniqueJobPtr;
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_FILTERCOMPATIBLETECHNIQUEJOB_H
+#endif // QT3DRENDER_RENDER_OPENGL_FILTERCOMPATIBLETECHNIQUEJOB_H

--- a/src/plugins/renderers/opengl/jobs/materialparametergathererjob.cpp
+++ b/src/plugins/renderers/opengl/jobs/materialparametergathererjob.cpp
@@ -50,6 +50,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 namespace {
 
 int materialParameterGathererCounter = 0;
@@ -123,6 +125,8 @@ void MaterialParameterGathererJob::run()
         }
     }
 }
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/jobs/materialparametergathererjob_p.h
+++ b/src/plugins/renderers/opengl/jobs/materialparametergathererjob_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_MATERIALPARAMETERGATHERERJOB_P_H
-#define QT3DRENDER_RENDER_MATERIALPARAMETERGATHERERJOB_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_MATERIALPARAMETERGATHERERJOB_P_H
+#define QT3DRENDER_RENDER_OPENGL_MATERIALPARAMETERGATHERERJOB_P_H
 
 //
 //  W A R N I N G
@@ -67,6 +67,8 @@ namespace Render {
 class NodeManagers;
 class TechniqueFilter;
 class RenderPassFilter;
+
+namespace OpenGL {
 class Renderer;
 
 // TO be executed for each FrameGraph branch with a given RenderPassFilter/TechniqueFilter
@@ -99,10 +101,12 @@ private:
 
 typedef QSharedPointer<MaterialParameterGathererJob> MaterialParameterGathererJobPtr;
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_MATERIALPARAMETERGATHERERJOB_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_MATERIALPARAMETERGATHERERJOB_P_H

--- a/src/plugins/renderers/opengl/jobs/renderviewbuilderjob.cpp
+++ b/src/plugins/renderers/opengl/jobs/renderviewbuilderjob.cpp
@@ -48,6 +48,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 namespace {
 int renderViewInstanceCounter = 0;
 } // anonymous
@@ -97,6 +99,8 @@ void RenderViewBuilderJob::run()
 
 
 }
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/jobs/renderviewbuilderjob_p.h
+++ b/src/plugins/renderers/opengl/jobs/renderviewbuilderjob_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERVIEWBUILDERJOB_P_H
-#define QT3DRENDER_RENDER_RENDERVIEWBUILDERJOB_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERVIEWBUILDERJOB_P_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERVIEWBUILDERJOB_P_H
 
 //
 //  W A R N I N G
@@ -60,6 +60,8 @@ QT_BEGIN_NAMESPACE
 namespace Qt3DRender {
 
 namespace Render {
+
+namespace OpenGL {
 
 class RenderView;
 class Renderer;
@@ -88,10 +90,12 @@ private:
 
 typedef QSharedPointer<RenderViewBuilderJob> RenderViewBuilderJobPtr;
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERVIEWBUILDERJOB_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERVIEWBUILDERJOB_P_H

--- a/src/plugins/renderers/opengl/jobs/renderviewinitializerjob.cpp
+++ b/src/plugins/renderers/opengl/jobs/renderviewinitializerjob.cpp
@@ -52,6 +52,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 namespace {
 // only accessed in ctor and dtor of RenderViewJob
@@ -98,6 +99,7 @@ void RenderViewInitializerJob::run()
 #endif
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/jobs/renderviewinitializerjob_p.h
+++ b/src/plugins/renderers/opengl/jobs/renderviewinitializerjob_p.h
@@ -38,8 +38,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERVIEWINITIALIZERJOB_H
-#define QT3DRENDER_RENDER_RENDERVIEWINITIALIZERJOB_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERVIEWINITIALIZERJOB_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERVIEWINITIALIZERJOB_H
 
 //
 //  W A R N I N G
@@ -63,8 +63,11 @@ namespace Qt3DRender {
 
 namespace Render {
 
-class Renderer;
 class FrameGraphNode;
+
+namespace OpenGL {
+
+class Renderer;
 class RenderView;
 
 class OPENGL_RENDERER_EXPORT RenderViewInitializerJob : public Qt3DCore::QAspectJob
@@ -100,9 +103,10 @@ private:
 
 typedef QSharedPointer<RenderViewInitializerJob> RenderViewInitializerJobPtr;
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERVIEWINITIALIZERJOB_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERVIEWINITIALIZERJOB_H

--- a/src/plugins/renderers/opengl/jobs/renderviewjobutils.cpp
+++ b/src/plugins/renderers/opengl/jobs/renderviewjobutils.cpp
@@ -75,6 +75,7 @@ using namespace Qt3DCore;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 /*!
     \internal
@@ -532,6 +533,7 @@ bool ParameterInfo::operator<(const int otherNameId) const Q_DECL_NOEXCEPT
     return nameId < otherNameId;
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/jobs/renderviewjobutils_p.h
+++ b/src/plugins/renderers/opengl/jobs/renderviewjobutils_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDERVIEWJOBUTILS_P_H
-#define QT3DRENDER_RENDERVIEWJOBUTILS_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERVIEWJOBUTILS_P_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERVIEWJOBUTILS_P_H
 
 //
 //  W A R N I N G
@@ -77,19 +77,21 @@ class Effect;
 class Entity;
 class Material;
 class RenderPass;
-class RenderStateSet;
 class Technique;
-class RenderView;
 class TechniqueFilter;
 class RenderPassFilter;
-class Renderer;
 class NodeManagers;
 class ShaderDataManager;
-struct ShaderUniform;
 class ShaderData;
 class TextureManager;
 class RenderStateManager;
 class RenderStateCollection;
+class RenderStateSet;
+
+namespace OpenGL {
+class Renderer;
+class RenderView;
+struct ShaderUniform;
 
 OPENGL_RENDERER_EXPORT void setRenderViewConfigFromFrameGraphLeafNode(RenderView *rv,
                                                                  const FrameGraphNode *fgLeaf);
@@ -128,7 +130,7 @@ struct RenderPassParameterData
     RenderPass *pass;
     ParameterInfoList parameterInfo;
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, RenderPassParameterData, Q_MOVABLE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, RenderPassParameterData, Q_MOVABLE_TYPE)
 
 using MaterialParameterGathererData = QHash<Qt3DCore::QNodeId, QVector<RenderPassParameterData>>;
 
@@ -181,9 +183,10 @@ struct OPENGL_RENDERER_EXPORT UniformBlockValueBuilder
     Matrix4x4 viewMatrix;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDERVIEWJOBUTILS_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERVIEWJOBUTILS_P_H

--- a/src/plugins/renderers/opengl/main.cpp
+++ b/src/plugins/renderers/opengl/main.cpp
@@ -50,7 +50,7 @@ class OpenGLRendererPlugin : public Qt3DRender::Render::QRendererPlugin
     Qt3DRender::Render::AbstractRenderer *create(const QString &key,  Qt3DRender::QRenderAspect::RenderType renderMode) override
     {
         Q_UNUSED(key)
-        return new Qt3DRender::Render::Renderer(renderMode);
+        return new Qt3DRender::Render::OpenGL::Renderer(renderMode);
     }
 };
 

--- a/src/plugins/renderers/opengl/managers/gl_handle_types_p.h
+++ b/src/plugins/renderers/opengl/managers/gl_handle_types_p.h
@@ -59,11 +59,15 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 class GLBuffer;
 class OpenGLVertexArrayObject;
 
 typedef Qt3DCore::QHandle<GLBuffer> HGLBuffer;
 typedef Qt3DCore::QHandle<OpenGLVertexArrayObject> HVao;
+
+} // namespace OpenGL
 
 } // namespace Render
 

--- a/src/plugins/renderers/opengl/managers/glbuffermanager_p.h
+++ b/src/plugins/renderers/opengl/managers/glbuffermanager_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GLBUFFERMANAGER_P_H
-#define QT3DRENDER_RENDER_GLBUFFERMANAGER_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GLBUFFERMANAGER_P_H
+#define QT3DRENDER_RENDER_OPENGL_GLBUFFERMANAGER_P_H
 
 //
 //  W A R N I N G
@@ -60,12 +60,16 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 class GLBufferManager : public Qt3DCore::QResourceManager<
         GLBuffer,
         Qt3DCore::QNodeId,
         Qt3DCore::NonLockingPolicy>
 {
 };
+
+} // OpenGL
 
 } // Render
 
@@ -74,4 +78,4 @@ class GLBufferManager : public Qt3DCore::QResourceManager<
 QT_END_NAMESPACE
 
 
-#endif // QT3DRENDER_RENDER_GLBUFFERMANAGER_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_GLBUFFERMANAGER_P_H

--- a/src/plugins/renderers/opengl/managers/glshadermanager_p.h
+++ b/src/plugins/renderers/opengl/managers/glshadermanager_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GLSHADERMANAGER_P_H
-#define QT3DRENDER_RENDER_GLSHADERMANAGER_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GLSHADERMANAGER_P_H
+#define QT3DRENDER_RENDER_OPENGL_GLSHADERMANAGER_P_H
 
 
 //
@@ -62,6 +62,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 class OPENGL_RENDERER_EXPORT GLShaderManager : public APIShaderManager<GLShader>
 {
 public:
@@ -70,6 +72,8 @@ public:
     {}
 };
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
@@ -77,4 +81,4 @@ public:
 QT_END_NAMESPACE
 
 
-#endif // QT3DRENDER_RENDER_GLSHADERMANAGER_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_GLSHADERMANAGER_P_H

--- a/src/plugins/renderers/opengl/managers/gltexturemanager_p.h
+++ b/src/plugins/renderers/opengl/managers/gltexturemanager_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GLTEXTUREMANAGER_H
-#define QT3DRENDER_RENDER_GLTEXTUREMANAGER_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GLTEXTUREMANAGER_H
+#define QT3DRENDER_RENDER_OPENGL_GLTEXTUREMANAGER_H
 
 //
 //  W A R N I N G
@@ -58,6 +58,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class OPENGL_RENDERER_EXPORT GLTextureManager : public APITextureManager<GLTexture, GLTexture::Image>
 {
@@ -71,9 +72,10 @@ public:
     {}
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GLTEXTUREMANAGER_H
+#endif // QT3DRENDER_RENDER_OPENGL_GLTEXTUREMANAGER_H

--- a/src/plugins/renderers/opengl/managers/vaomanager_p.h
+++ b/src/plugins/renderers/opengl/managers/vaomanager_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_VAOMANAGER_P_H
-#define QT3DRENDER_RENDER_VAOMANAGER_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_VAOMANAGER_P_H
+#define QT3DRENDER_RENDER_OPENGL_VAOMANAGER_P_H
 
 //
 //  W A R N I N G
@@ -61,6 +61,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 class OPENGL_RENDERER_EXPORT VAOManager : public Qt3DCore::QResourceManager<
         OpenGLVertexArrayObject,
         VAOIdentifier,
@@ -70,12 +72,14 @@ public:
     VAOManager() {}
 };
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
 
-Q_DECLARE_RESOURCE_INFO(Qt3DRender::Render::OpenGLVertexArrayObject, Q_REQUIRES_CLEANUP)
+Q_DECLARE_RESOURCE_INFO(Qt3DRender::Render::OpenGL::OpenGLVertexArrayObject, Q_REQUIRES_CLEANUP)
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_VAOMANAGER_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_VAOMANAGER_P_H

--- a/src/plugins/renderers/opengl/renderer/commandexecuter.cpp
+++ b/src/plugins/renderers/opengl/renderer/commandexecuter.cpp
@@ -242,11 +242,11 @@ QJsonObject backendNodeToJSon(Handle handle, Manager *manager)
     return obj;
 }
 
-QJsonObject parameterPackToJson(const Render::ShaderParameterPack &pack)
+QJsonObject parameterPackToJson(const Render::OpenGL::ShaderParameterPack &pack)
 {
     QJsonObject obj;
 
-    const Render::PackUniformHash &uniforms = pack.uniforms();
+    const Render::OpenGL::PackUniformHash &uniforms = pack.uniforms();
     QJsonArray uniformsArray;
     for (auto it = uniforms.cbegin(), end = uniforms.cend(); it != end; ++it) {
         QJsonObject uniformObj;
@@ -261,7 +261,7 @@ QJsonObject parameterPackToJson(const Render::ShaderParameterPack &pack)
     obj.insert(QLatin1String("uniforms"), uniformsArray);
 
     QJsonArray texturesArray;
-    const QVector<Render::ShaderParameterPack::NamedTexture> &textures = pack.textures();
+    const QVector<Render::OpenGL::ShaderParameterPack::NamedTexture> &textures = pack.textures();
     for (const auto & texture : textures) {
         QJsonObject textureObj;
         textureObj.insert(QLatin1String("name"), Render::StringToInt::lookupString(texture.glslNameId));
@@ -270,7 +270,7 @@ QJsonObject parameterPackToJson(const Render::ShaderParameterPack &pack)
     }
     obj.insert(QLatin1String("textures"), texturesArray);
 
-    const QVector<Render::BlockToUBO> &ubos = pack.uniformBuffers();
+    const QVector<Render::OpenGL::BlockToUBO> &ubos = pack.uniformBuffers();
     QJsonArray ubosArray;
     for (const auto &ubo : ubos) {
         QJsonObject uboObj;
@@ -281,7 +281,7 @@ QJsonObject parameterPackToJson(const Render::ShaderParameterPack &pack)
     }
     obj.insert(QLatin1String("ubos"), ubosArray);
 
-    const QVector<Render::BlockToSSBO> &ssbos = pack.shaderStorageBuffers();
+    const QVector<Render::OpenGL::BlockToSSBO> &ssbos = pack.shaderStorageBuffers();
     QJsonArray ssbosArray;
     for (const auto &ssbo : ssbos) {
         QJsonObject ssboObj;
@@ -296,13 +296,13 @@ QJsonObject parameterPackToJson(const Render::ShaderParameterPack &pack)
 
 } // anonymous
 
-CommandExecuter::CommandExecuter(Render::Renderer *renderer)
+CommandExecuter::CommandExecuter(Render::OpenGL::Renderer *renderer)
     : m_renderer(renderer)
 {
 }
 
 // Render thread
-void CommandExecuter::performAsynchronousCommandExecution(const QVector<Render::RenderView *> &views)
+void CommandExecuter::performAsynchronousCommandExecution(const QVector<Render::OpenGL::RenderView *> &views)
 {
     QMutexLocker lock(&m_pendingCommandsMutex);
     const QVector<Qt3DCore::Debug::AsynchronousCommandReply *> shellCommands = std::move(m_pendingCommands);
@@ -334,7 +334,7 @@ void CommandExecuter::performAsynchronousCommandExecution(const QVector<Render::
             QJsonObject replyObj;
 
             QJsonArray viewArray;
-            for (Render::RenderView *v : views) {
+            for (Render::OpenGL::RenderView *v : views) {
                 QJsonObject viewObj;
                 viewObj.insert(QLatin1String("viewport"), typeToJsonValue(v->viewport()));
                 viewObj.insert(QLatin1String("surfaceSize"), typeToJsonValue(v->surfaceSize()));
@@ -346,7 +346,7 @@ void CommandExecuter::performAsynchronousCommandExecution(const QVector<Render::
                 viewObj.insert(QLatin1String("clearStencilValue"), v->clearStencilValue());
 
                 QJsonArray renderCommandsArray;
-                for (Render::RenderCommand *c : v->commands()) {
+                for (Render::OpenGL::RenderCommand *c : v->commands()) {
                     QJsonObject commandObj;
                     Render::NodeManagers *nodeManagers = m_renderer->nodeManagers();
                     commandObj.insert(QLatin1String("shader"), typeToJsonValue(QVariant::fromValue(c->m_shaderId)));

--- a/src/plugins/renderers/opengl/renderer/commandexecuter_p.h
+++ b/src/plugins/renderers/opengl/renderer/commandexecuter_p.h
@@ -65,8 +65,10 @@ class AsynchronousCommandReply;
 namespace Qt3DRender {
 
 namespace Render {
+namespace OpenGL {
 class Renderer;
 class RenderView;
+} // OpenGL
 } // Render
 
 namespace Debug {
@@ -74,14 +76,14 @@ namespace Debug {
 class CommandExecuter
 {
 public:
-    explicit CommandExecuter(Render::Renderer *renderer);
+    explicit CommandExecuter(Render::OpenGL::Renderer *renderer);
 
-    void performAsynchronousCommandExecution(const QVector<Render::RenderView *> &views);
+    void performAsynchronousCommandExecution(const QVector<Render::OpenGL::RenderView *> &views);
 
     QVariant executeCommand(const QStringList &args);
 
 private:
-    Render::Renderer *m_renderer;
+    Render::OpenGL::Renderer *m_renderer;
     QVector<Qt3DCore::Debug::AsynchronousCommandReply *> m_pendingCommands;
     QMutex m_pendingCommandsMutex;
 };

--- a/src/plugins/renderers/opengl/renderer/commandthread.cpp
+++ b/src/plugins/renderers/opengl/renderer/commandthread.cpp
@@ -51,6 +51,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 CommandThread::CommandThread(Renderer *renderer)
     : QThread()
     , m_renderer(renderer)
@@ -188,6 +190,8 @@ void CommandThread::run()
         m_commandExecutionSemaphore.release();
     }
 }
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/renderer/commandthread_p.h
+++ b/src/plugins/renderers/opengl/renderer/commandthread_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_COMMANDTHREAD_P_H
-#define QT3DRENDER_RENDER_COMMANDTHREAD_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_COMMANDTHREAD_P_H
+#define QT3DRENDER_RENDER_OPENGL_COMMANDTHREAD_P_H
 
 //
 //  W A R N I N G
@@ -63,9 +63,12 @@ namespace Qt3DRender {
 
 namespace Render {
 
+class OffscreenSurfaceHelper;
+
+namespace OpenGL {
+
 class Renderer;
 class GLCommand;
-class OffscreenSurfaceHelper;
 class GraphicsContext;
 
 class CommandThread : public QThread
@@ -75,7 +78,7 @@ public:
     explicit CommandThread(Renderer *renderer);
     ~CommandThread();
 
-    Render::Renderer* renderer() const { return m_renderer; }
+    Renderer* renderer() const { return m_renderer; }
 
     void initialize(QOpenGLContext *mainContext, OffscreenSurfaceHelper *offsreenSurfaceHelper);
     void shutdown();
@@ -84,7 +87,7 @@ public:
 
 private:
     void run() override;
-    void executeCommandInternal(Qt3DRender::Render::GLCommand *command);
+    void executeCommandInternal(GLCommand *command);
 
 private:
     Renderer* m_renderer;
@@ -101,10 +104,12 @@ private:
     QAtomicInt m_running;
 };
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_COMMANDTHREAD_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_COMMANDTHREAD_P_H

--- a/src/plugins/renderers/opengl/renderer/glcommands.cpp
+++ b/src/plugins/renderers/opengl/renderer/glcommands.cpp
@@ -49,6 +49,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 LoadShaderCommand::LoadShaderCommand(Shader *shader)
     : m_shader(shader)
 {
@@ -61,6 +63,8 @@ void LoadShaderCommand::execute(Renderer *renderer, GraphicsContext *ctx)
     GLResourceManagers *glResourceManagers = renderer->glResourceManagers();
     ctx->loadShader(m_shader, nodeManagers->shaderManager(), glResourceManagers->glShaderManager());
 }
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/renderer/glcommands_p.h
+++ b/src/plugins/renderers/opengl/renderer/glcommands_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GLCOMMANDS_P_H
-#define QT3DRENDER_RENDER_GLCOMMANDS_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GLCOMMANDS_P_H
+#define QT3DRENDER_RENDER_OPENGL_GLCOMMANDS_P_H
 
 //
 //  W A R N I N G
@@ -60,9 +60,12 @@ namespace Qt3DRender {
 
 namespace Render {
 
+class Shader;
+
+namespace OpenGL {
+
 class GraphicsContext;
 class Renderer;
-class Shader;
 
 class GLCommand
 {
@@ -80,10 +83,13 @@ public:
 private:
     Shader *m_shader = nullptr;
 };
+
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GLCOMMANDS_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_GLCOMMANDS_P_H

--- a/src/plugins/renderers/opengl/renderer/glresourcemanagers.cpp
+++ b/src/plugins/renderers/opengl/renderer/glresourcemanagers.cpp
@@ -53,6 +53,7 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
 
 GLResourceManagers::GLResourceManagers(NodeManagers *nodeManagers)
     : m_nodeManagers(nodeManagers)
@@ -72,6 +73,8 @@ GLResourceManagers::~GLResourceManagers()
     delete m_glBufferManager;
     delete m_vaoManager;
 }
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/renderer/glresourcemanagers_p.h
+++ b/src/plugins/renderers/opengl/renderer/glresourcemanagers_p.h
@@ -59,11 +59,13 @@ QT_BEGIN_NAMESPACE
 namespace Qt3DRender {
 
 namespace Render {
+class NodeManagers;
+
+namespace OpenGL {
 
 class GLBufferManager;
 class GLShaderManager;
 class GLTextureManager;
-class NodeManagers;
 class VAOManager;
 
 class OPENGL_RENDERER_EXPORT GLResourceManagers
@@ -84,6 +86,8 @@ private:
     GLTextureManager *m_glTextureManager;
     VAOManager *m_vaoManager;
 };
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/renderer/glshader.cpp
+++ b/src/plugins/renderers/opengl/renderer/glshader.cpp
@@ -41,12 +41,15 @@
 #include <QMutexLocker>
 #include <Qt3DRender/private/stringtoint_p.h>
 #include <graphicscontext_p.h>
+#include <logging_p.h>
 
 QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 
 namespace Render {
+
+namespace OpenGL {
 
 GLShader::GLShader()
     : m_isLoaded(false)
@@ -273,6 +276,8 @@ void GLShader::initializeShaderStorageBlocks(const QVector<ShaderStorageBlock> &
         qCDebug(Shaders) << "Initializing Shader Storage Block {" << m_shaderStorageBlockNames[i] << "}";
     }
 }
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/renderer/glshader_p.h
+++ b/src/plugins/renderers/opengl/renderer/glshader_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GLSHADER_P_H
-#define QT3DRENDER_RENDER_GLSHADER_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GLSHADER_P_H
+#define QT3DRENDER_RENDER_OPENGL_GLSHADER_P_H
 
 //
 //  W A R N I N G
@@ -65,6 +65,8 @@ class QOpenGLShaderProgram;
 namespace Qt3DRender {
 
 namespace Render {
+
+namespace OpenGL {
 
 class OPENGL_RENDERER_EXPORT GLShader
 {
@@ -149,10 +151,12 @@ private:
     QMetaObject::Connection m_contextConnection;
 };
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GLSHADER_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_GLSHADER_P_H

--- a/src/plugins/renderers/opengl/renderer/logging.cpp
+++ b/src/plugins/renderers/opengl/renderer/logging.cpp
@@ -45,6 +45,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 Q_LOGGING_CATEGORY(Backend, "Qt3D.Renderer.OpenGL.Backend", QtWarningMsg)
 Q_LOGGING_CATEGORY(Frontend, "Qt3D.Renderer.OpenGL.Frontend", QtWarningMsg)
 Q_LOGGING_CATEGORY(Io, "Qt3D.Renderer.OpenGL.IO", QtWarningMsg)
@@ -57,6 +59,8 @@ Q_LOGGING_CATEGORY(Memory, "Qt3D.Renderer.OpenGL.Memory", QtWarningMsg)
 Q_LOGGING_CATEGORY(Shaders, "Qt3D.Renderer.OpenGL.Shaders", QtWarningMsg)
 Q_LOGGING_CATEGORY(RenderStates, "Qt3D.Renderer.OpenGL.RenderStates", QtWarningMsg)
 Q_LOGGING_CATEGORY(VSyncAdvanceService, "Qt3D.Renderer.OpenGL.VsyncAdvanceService", QtWarningMsg)
+
+} // namespace OpenGL
 
 } // namespace Render
 

--- a/src/plugins/renderers/opengl/renderer/logging_p.h
+++ b/src/plugins/renderers/opengl/renderer/logging_p.h
@@ -59,6 +59,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 Q_DECLARE_LOGGING_CATEGORY(Backend)
 Q_DECLARE_LOGGING_CATEGORY(Frontend)
 Q_DECLARE_LOGGING_CATEGORY(Io)
@@ -71,6 +73,8 @@ Q_DECLARE_LOGGING_CATEGORY(Memory)
 Q_DECLARE_LOGGING_CATEGORY(Shaders)
 Q_DECLARE_LOGGING_CATEGORY(RenderStates)
 Q_DECLARE_LOGGING_CATEGORY(VSyncAdvanceService)
+
+} // namespace OpenGL
 
 } // namespace Render
 

--- a/src/plugins/renderers/opengl/renderer/openglvertexarrayobject.cpp
+++ b/src/plugins/renderers/opengl/renderer/openglvertexarrayobject.cpp
@@ -49,6 +49,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 OpenGLVertexArrayObject::OpenGLVertexArrayObject()
     : m_ctx(nullptr)
@@ -156,6 +157,7 @@ void OpenGLVertexArrayObject::saveVertexAttribute(const SubmissionContext::VAOVe
 }
 
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/renderer/openglvertexarrayobject_p.h
+++ b/src/plugins/renderers/opengl/renderer/openglvertexarrayobject_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef OPENGLVERTEXARRAYOBJECT_H
-#define OPENGLVERTEXARRAYOBJECT_H
+#ifndef QT3DRENDER_RENDER_OPENGL_OPENGLVERTEXARRAYOBJECT_H
+#define QT3DRENDER_RENDER_OPENGL_OPENGLVERTEXARRAYOBJECT_H
 
 //
 //  W A R N I N G
@@ -61,9 +61,12 @@ namespace Qt3DRender {
 namespace Render {
 
 class GeometryManager;
-class GLShaderManager;
 
 typedef QPair<HGeometry, Qt3DCore::QNodeId> VAOIdentifier;
+
+namespace OpenGL {
+
+class GLShaderManager;
 
 class OpenGLVertexArrayObject
 {
@@ -103,9 +106,10 @@ private:
     SubmissionContext::VAOIndexAttribute m_indexAttribute;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // OPENGLVERTEXARRAYOBJECT_H
+#endif // QT3DRENDER_RENDER_OPENGL_OPENGLVERTEXARRAYOBJECT_H

--- a/src/plugins/renderers/opengl/renderer/rendercommand.cpp
+++ b/src/plugins/renderers/opengl/renderer/rendercommand.cpp
@@ -43,6 +43,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 RenderCommand::RenderCommand()
     : m_glShader(nullptr)
@@ -71,6 +72,7 @@ RenderCommand::RenderCommand()
    m_workGroups[2] = 0;
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/renderer/rendercommand_p.h
+++ b/src/plugins/renderers/opengl/renderer/rendercommand_p.h
@@ -38,8 +38,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERCOMMAND_H
-#define QT3DRENDER_RENDER_RENDERCOMMAND_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERCOMMAND_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERCOMMAND_H
 
 //
 //  W A R N I N G
@@ -71,6 +71,9 @@ namespace Qt3DRender {
 namespace Render {
 
 class RenderStateSet;
+
+namespace OpenGL {
+
 class GLShader;
 
 class OPENGL_RENDERER_EXPORT RenderCommand
@@ -124,10 +127,12 @@ public:
     bool m_isValid;
 };
 
+} // namespace OpenGL
+
 } // namespace Render
 
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERCOMMAND_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERCOMMAND_H

--- a/src/plugins/renderers/opengl/renderer/renderer_p.h
+++ b/src/plugins/renderers/opengl/renderer/renderer_p.h
@@ -38,8 +38,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERER_H
-#define QT3DRENDER_RENDER_RENDERER_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERER_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERER_H
 
 //
 //  W A R N I N G
@@ -128,29 +128,32 @@ class CommandExecuter;
 namespace Render {
 
 class CameraLens;
-class SubmissionContext;
 class FrameGraphNode;
 class Material;
 class Technique;
 class Shader;
 class Entity;
-class RenderCommand;
-class RenderQueue;
-class RenderView;
 class Effect;
 class RenderPass;
 class RenderThread;
-class CommandThread;
 class RenderStateSet;
 class VSyncFrameAdvanceService;
 class PickEventFilter;
 class NodeManagers;
-class GLResourceManagers;
-class GLShader;
 class ResourceAccessor;
 
 class UpdateLevelOfDetailJob;
 typedef QSharedPointer<UpdateLevelOfDetailJob> UpdateLevelOfDetailJobPtr;
+
+namespace OpenGL {
+
+class CommandThread;
+class SubmissionContext;
+class RenderCommand;
+class RenderQueue;
+class RenderView;
+class GLShader;
+class GLResourceManagers;
 
 using SynchronizerJobPtr = GenericLambdaJobPtr<std::function<void()>>;
 using IntrospectShadersJobPtr = GenericLambdaJobPtr<std::function<void()>>;
@@ -291,7 +294,7 @@ public:
         QSurface *surface;
     };
 
-    ViewSubmissionResultData submitRenderViews(const QVector<Render::RenderView *> &renderViews);
+    ViewSubmissionResultData submitRenderViews(const QVector<RenderView *> &renderViews);
 
     RendererCache *cache() { return &m_cache; }
 
@@ -412,9 +415,10 @@ private:
     QSharedPointer<ResourceAccessor> m_scene2DResourceAccessor;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERER_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERER_H

--- a/src/plugins/renderers/opengl/renderer/renderercache_p.h
+++ b/src/plugins/renderers/opengl/renderer/renderercache_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERERCACHE_P_H
-#define QT3DRENDER_RENDER_RENDERERCACHE_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERERCACHE_P_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERERCACHE_P_H
 
 //
 //  W A R N I N G
@@ -62,6 +62,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 struct RendererCache
 {
     struct LeafNodeData
@@ -78,10 +80,12 @@ private:
     QMutex m_mutex;
 };
 
+} // namespace OpenGL
+
 } // namespace Render
 
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERERCACHE_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERERCACHE_P_H

--- a/src/plugins/renderers/opengl/renderer/renderqueue.cpp
+++ b/src/plugins/renderers/opengl/renderer/renderqueue.cpp
@@ -47,6 +47,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 RenderQueue::RenderQueue()
     : m_noRender(false)
     , m_wasReset(true)
@@ -125,6 +127,8 @@ bool RenderQueue::isFrameQueueComplete() const
     return (m_noRender
             || (m_targetRenderViewCount > 0 && m_targetRenderViewCount == m_currentRenderViewCount));
 }
+
+} // namespace OpenGL
 
 } // namespace Render
 

--- a/src/plugins/renderers/opengl/renderer/renderqueue_p.h
+++ b/src/plugins/renderers/opengl/renderer/renderqueue_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERQUEUE_H
-#define QT3DRENDER_RENDER_RENDERQUEUE_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERQUEUE_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERQUEUE_H
 
 //
 //  W A R N I N G
@@ -61,6 +61,8 @@ QT_BEGIN_NAMESPACE
 namespace Qt3DRender {
 
 namespace Render {
+
+namespace OpenGL {
 
 class RenderView;
 
@@ -94,10 +96,12 @@ private:
     QMutex m_mutex;
 };
 
+} // namespace OpenGL
+
 } // namespace Render
 
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERQUEUE_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERQUEUE_H

--- a/src/plugins/renderers/opengl/renderer/renderview.cpp
+++ b/src/plugins/renderers/opengl/renderer/renderview.cpp
@@ -85,6 +85,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 
 namespace  {
@@ -1113,6 +1114,7 @@ void RenderView::setIsDownloadBuffersEnable(bool isDownloadBuffersEnable)
     m_isDownloadBuffersEnable = isDownloadBuffersEnable;
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/renderer/renderview_p.h
+++ b/src/plugins/renderers/opengl/renderer/renderview_p.h
@@ -38,8 +38,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERVIEW_H
-#define QT3DRENDER_RENDER_RENDERVIEW_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERVIEW_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERVIEW_H
 
 //
 //  W A R N I N G
@@ -86,14 +86,17 @@ class QRenderPass;
 
 namespace Render {
 
-class Renderer;
 class NodeManagers;
-class RenderCommand;
 class RenderPassFilter;
 class TechniqueFilter;
 class ViewportNode;
 class Effect;
 class RenderPass;
+
+namespace OpenGL {
+
+class Renderer;
+class RenderCommand;
 
 typedef QPair<ShaderUniform, QVariant> ActivePropertyContent;
 typedef QPair<QString, ActivePropertyContent > ActiveProperty;
@@ -372,9 +375,10 @@ private:
                                                const QString &structName) const;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERVIEW_H
+#endif // QT3DRENDER_RENDER_OPENGL_ENDERVIEW_H

--- a/src/plugins/renderers/opengl/renderer/renderviewbuilder.cpp
+++ b/src/plugins/renderers/opengl/renderer/renderviewbuilder.cpp
@@ -47,6 +47,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 const int RenderViewBuilder::m_optimalParallelJobCount = std::max(QThread::idealThreadCount(), 2);
 
 namespace {
@@ -460,7 +462,7 @@ void RenderViewBuilder::prepareJobs()
     // Estimate the number of jobs to create based on the number of entities
     m_renderViewBuilderJobs.reserve(RenderViewBuilder::m_optimalParallelJobCount);
     for (auto i = 0; i < RenderViewBuilder::m_optimalParallelJobCount; ++i) {
-        auto renderViewCommandBuilder = Render::RenderViewBuilderJobPtr::create();
+        auto renderViewCommandBuilder = RenderViewBuilderJobPtr::create();
         renderViewCommandBuilder->setIndex(m_renderViewIndex);
         renderViewCommandBuilder->setRenderer(m_renderer);
         m_renderViewBuilderJobs.push_back(renderViewCommandBuilder);
@@ -473,7 +475,7 @@ void RenderViewBuilder::prepareJobs()
         const int lastRemaingElements = materialHandles.size() % RenderViewBuilder::m_optimalParallelJobCount;
         m_materialGathererJobs.reserve(RenderViewBuilder::m_optimalParallelJobCount);
         for (auto i = 0; i < RenderViewBuilder::m_optimalParallelJobCount; ++i) {
-            auto materialGatherer = Render::MaterialParameterGathererJobPtr::create();
+            auto materialGatherer = MaterialParameterGathererJobPtr::create();
             materialGatherer->setNodeManagers(m_renderer->nodeManagers());
             if (i == RenderViewBuilder::m_optimalParallelJobCount - 1)
                 materialGatherer->setHandles(materialHandles.mid(i * elementsPerJob, elementsPerJob + lastRemaingElements));
@@ -663,6 +665,8 @@ QVector<Entity *> RenderViewBuilder::entitiesInSubset(const QVector<Entity *> &e
 
     return intersection;
 }
+
+} // OpenGL
 
 } // Render
 

--- a/src/plugins/renderers/opengl/renderer/renderviewbuilder_p.h
+++ b/src/plugins/renderers/opengl/renderer/renderviewbuilder_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERVIEWBUILDER_H
-#define QT3DRENDER_RENDER_RENDERVIEWBUILDER_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERVIEWBUILDER_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERVIEWBUILDER_H
 
 //
 //  W A R N I N G
@@ -70,6 +70,8 @@ QT_BEGIN_NAMESPACE
 namespace Qt3DRender {
 
 namespace Render {
+
+namespace OpenGL {
 
 class Renderer;
 
@@ -141,10 +143,12 @@ private:
     static const int m_optimalParallelJobCount;
 };
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERVIEWBUILDER_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERVIEWBUILDER_H

--- a/src/plugins/renderers/opengl/renderer/shaderparameterpack.cpp
+++ b/src/plugins/renderers/opengl/renderer/shaderparameterpack.cpp
@@ -54,6 +54,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 ShaderParameterPack::~ShaderParameterPack()
 {
@@ -94,6 +95,7 @@ void ShaderParameterPack::setSubmissionUniform(const ShaderUniform &uniform)
     m_submissionUniforms.push_back(uniform);
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/renderer/shaderparameterpack_p.h
+++ b/src/plugins/renderers/opengl/renderer/shaderparameterpack_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_SHADERPARAMETERPACK_P_H
-#define QT3DRENDER_RENDER_SHADERPARAMETERPACK_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_SHADERPARAMETERPACK_P_H
+#define QT3DRENDER_RENDER_OPENGL_SHADERPARAMETERPACK_P_H
 
 //
 //  W A R N I N G
@@ -72,6 +72,7 @@ class QFrameAllocator;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class GraphicsContext;
 
@@ -81,13 +82,13 @@ struct BlockToUBO {
     bool m_needsUpdate;
     QHash<QString, QVariant> m_updatedProperties;
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, BlockToUBO, Q_MOVABLE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, BlockToUBO, Q_MOVABLE_TYPE)
 
 struct BlockToSSBO {
     int m_blockIndex;
     Qt3DCore::QNodeId m_bufferID;
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, BlockToSSBO, Q_PRIMITIVE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, BlockToSSBO, Q_PRIMITIVE_TYPE)
 
 
 typedef QHash<int, UniformValue> PackUniformHash;
@@ -135,13 +136,14 @@ private:
 
     friend class RenderView;
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, ShaderParameterPack::NamedTexture, Q_PRIMITIVE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, ShaderParameterPack::NamedTexture, Q_PRIMITIVE_TYPE)
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-Q_DECLARE_METATYPE(Qt3DRender::Render::ShaderParameterPack)
+Q_DECLARE_METATYPE(Qt3DRender::Render::OpenGL::ShaderParameterPack)
 
-#endif // QT3DRENDER_RENDER_SHADERPARAMETERPACK_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_SHADERPARAMETERPACK_P_H

--- a/src/plugins/renderers/opengl/renderer/shadervariables_p.h
+++ b/src/plugins/renderers/opengl/renderer/shadervariables_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_SHADERVARIABLES_P_H
-#define QT3DRENDER_RENDER_SHADERVARIABLES_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_SHADERVARIABLES_P_H
+#define QT3DRENDER_RENDER_OPENGL_SHADERVARIABLES_P_H
 
 //
 //  W A R N I N G
@@ -60,6 +60,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 struct ShaderAttribute
 {
     ShaderAttribute()
@@ -75,7 +77,7 @@ struct ShaderAttribute
     int m_size;
     int m_location;
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, ShaderAttribute, Q_MOVABLE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, ShaderAttribute, Q_MOVABLE_TYPE)
 
 struct ShaderUniform
 {
@@ -103,7 +105,7 @@ struct ShaderUniform
     uint m_rawByteSize; // contains byte size (size / type / strides)
     // size, offset and strides are in bytes
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, ShaderUniform, Q_MOVABLE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, ShaderUniform, Q_MOVABLE_TYPE)
 
 struct ShaderUniformBlock
 {
@@ -122,7 +124,7 @@ struct ShaderUniformBlock
     int m_activeUniformsCount;
     int m_size;
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, ShaderUniformBlock, Q_MOVABLE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, ShaderUniformBlock, Q_MOVABLE_TYPE)
 
 struct ShaderStorageBlock
 {
@@ -141,7 +143,9 @@ struct ShaderStorageBlock
     int m_size;
     int m_activeVariablesCount;
 };
-QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, ShaderStorageBlock, Q_MOVABLE_TYPE)
+QT3D_DECLARE_TYPEINFO_3(Qt3DRender, Render, OpenGL, ShaderStorageBlock, Q_MOVABLE_TYPE)
+
+} // namespace OpenGL
 
 } // namespace Render
 
@@ -149,4 +153,4 @@ QT3D_DECLARE_TYPEINFO_2(Qt3DRender, Render, ShaderStorageBlock, Q_MOVABLE_TYPE)
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_SHADERVARIABLES_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_SHADERVARIABLES_P_H

--- a/src/plugins/renderers/opengl/textures/gltexture.cpp
+++ b/src/plugins/renderers/opengl/textures/gltexture.cpp
@@ -61,6 +61,7 @@ using namespace Qt3DCore;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 GLTexture::GLTexture(TextureDataManager *texDataMgr,
                      TextureImageDataManager *texImgDataMgr,
@@ -464,6 +465,7 @@ void GLTexture::updateGLTextureParameters()
 }
 
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/textures/gltexture_p.h
+++ b/src/plugins/renderers/opengl/textures/gltexture_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_GLTEXTURE_H
-#define QT3DRENDER_RENDER_GLTEXTURE_H
+#ifndef QT3DRENDER_RENDER_OPENGL_GLTEXTURE_H
+#define QT3DRENDER_RENDER_OPENGL_GLTEXTURE_H
 
 //
 //  W A R N I N G
@@ -70,9 +70,14 @@ class QOpenGLTexture;
 namespace Qt3DRender {
 namespace Render {
 
+template<class APITexture, class APITextureImage>
+class APITextureManager;
+
 class TextureImageManager;
 class TextureDataManager;
 class TextureImageDataManager;
+
+namespace OpenGL {
 class RenderBuffer;
 
 /**
@@ -176,7 +181,7 @@ public:
 
 protected:
     template<class APITexture, class APITextureImage>
-    friend class APITextureManager;
+    friend class Render::APITextureManager;
 
     /*
      * These methods are to be accessed from the GLTextureManager.
@@ -240,9 +245,10 @@ private:
     QVector<QTextureImageDataPtr> m_imageData;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_GLTEXTURE_H
+#endif // QT3DRENDER_RENDER_OPENGL_GLTEXTURE_H

--- a/src/plugins/renderers/opengl/textures/renderbuffer.cpp
+++ b/src/plugins/renderers/opengl/textures/renderbuffer.cpp
@@ -45,6 +45,7 @@ QT_BEGIN_NAMESPACE
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 RenderBuffer::RenderBuffer(int width, int height, QAbstractTexture::TextureFormat format)
     : m_size(width, height),
@@ -106,6 +107,7 @@ void RenderBuffer::release()
     m_context->functions()->glBindRenderbuffer(GL_RENDERBUFFER, 0);
 }
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 

--- a/src/plugins/renderers/opengl/textures/renderbuffer_p.h
+++ b/src/plugins/renderers/opengl/textures/renderbuffer_p.h
@@ -37,8 +37,8 @@
 **
 ****************************************************************************/
 
-#ifndef QT3DRENDER_RENDER_RENDERBUFFER_P_H
-#define QT3DRENDER_RENDER_RENDERBUFFER_P_H
+#ifndef QT3DRENDER_RENDER_OPENGL_RENDERBUFFER_P_H
+#define QT3DRENDER_RENDER_OPENGL_RENDERBUFFER_P_H
 
 //
 //  W A R N I N G
@@ -60,6 +60,7 @@ class QOpenGLContext;
 
 namespace Qt3DRender {
 namespace Render {
+namespace OpenGL {
 
 class OPENGL_RENDERER_EXPORT RenderBuffer
 {
@@ -83,9 +84,10 @@ private:
     QOpenGLContext *m_context;
 };
 
+} // namespace OpenGL
 } // namespace Render
 } // namespace Qt3DRender
 
 QT_END_NAMESPACE
 
-#endif // QT3DRENDER_RENDER_RENDERBUFFER_P_H
+#endif // QT3DRENDER_RENDER_OPENGL_RENDERBUFFER_P_H

--- a/src/render/frontend/qrenderaspect.cpp
+++ b/src/render/frontend/qrenderaspect.cpp
@@ -654,6 +654,7 @@ Render::AbstractRenderer *QRenderAspectPrivate::loadRendererPlugin()
         if (renderer)
             return renderer;
     }
+    qFatal("Unable to load a renderer plugin");
     return nullptr;
 }
 

--- a/src/render/materialsystem/shader_p.h
+++ b/src/render/materialsystem/shader_p.h
@@ -91,6 +91,11 @@ public:
     void submitPendingNotifications();
     inline bool hasPendingNotifications() const { return !m_pendingNotifications.empty(); }
 
+    // Set by Renderer plugin
+    void setLog(const QString &log);
+    void setStatus(QShaderProgram::Status status);
+    void initializeFromReference(const Shader &other);
+
 private:
     void initializeFromPeer(const Qt3DCore::QNodeCreatedChangeBasePtr &change) final;
 
@@ -102,12 +107,6 @@ private:
     bool m_dirty;
 
     QVector<Qt3DCore::QPropertyUpdatedChangePtr> m_pendingNotifications;
-
-    void initializeFromReference(const Shader &other);
-    void setLog(const QString &log);
-    void setStatus(QShaderProgram::Status status);
-
-    friend class GraphicsContext;
 };
 
 #ifndef QT_NO_DEBUG_STREAM

--- a/tests/auto/render/opengl/filtercompatibletechniquejob/tst_filtercompatibletechniquejob.cpp
+++ b/tests/auto/render/opengl/filtercompatibletechniquejob/tst_filtercompatibletechniquejob.cpp
@@ -96,9 +96,9 @@ public:
         renderer()->submissionContext()->beginDrawing(m_window.data());
     }
 
-    Render::Renderer *renderer() const
+    Render::OpenGL::Renderer *renderer() const
     {
-        return static_cast<Render::Renderer *>(d_func()->m_renderer);
+        return static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer);
     }
 
     void onRegistered() { QRenderAspect::onRegistered(); }
@@ -175,7 +175,7 @@ private Q_SLOTS:
     void checkInitialState()
     {
         // GIVEN
-        Qt3DRender::Render::FilterCompatibleTechniqueJob backendFilterCompatibleTechniqueJob;
+        Qt3DRender::Render::OpenGL::FilterCompatibleTechniqueJob backendFilterCompatibleTechniqueJob;
 
         // THEN
         QVERIFY(backendFilterCompatibleTechniqueJob.manager() == nullptr);
@@ -183,7 +183,7 @@ private Q_SLOTS:
 
         // WHEN
         Qt3DRender::Render::TechniqueManager techniqueManager;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Qt3DRender::Render::OpenGL::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         backendFilterCompatibleTechniqueJob.setManager(&techniqueManager);
         backendFilterCompatibleTechniqueJob.setRenderer(&renderer);
 
@@ -195,7 +195,7 @@ private Q_SLOTS:
     void checkRunRendererRunning()
     {
         // GIVEN
-        Qt3DRender::Render::FilterCompatibleTechniqueJob backendFilterCompatibleTechniqueJob;
+        Qt3DRender::Render::OpenGL::FilterCompatibleTechniqueJob backendFilterCompatibleTechniqueJob;
         Qt3DRender::TestAspect testAspect(buildTestScene());
 
         // WHEN

--- a/tests/auto/render/opengl/glshadermanager/tst_glshadermanager.cpp
+++ b/tests/auto/render/opengl/glshadermanager/tst_glshadermanager.cpp
@@ -46,7 +46,7 @@ private Q_SLOTS:
 void tst_GLShaderManager::adopt()
 {
     // GIVEN
-    Qt3DRender::Render::GLShaderManager cache;
+    Qt3DRender::Render::OpenGL::GLShaderManager cache;
     Qt3DRender::QShaderProgram frontendShader1;
     Qt3DRender::QShaderProgram frontendShader2;
     TestRenderer renderer;
@@ -64,7 +64,7 @@ void tst_GLShaderManager::adopt()
     QVERIFY(backendShaderNode1.peerId() != backendShaderNode2.peerId());
 
     // WHEN
-    Qt3DRender::Render::GLShader *glShader1 = cache.createOrAdoptExisting(&backendShaderNode1);
+    Qt3DRender::Render::OpenGL::GLShader *glShader1 = cache.createOrAdoptExisting(&backendShaderNode1);
 
     // THEN
     QVERIFY(glShader1 != nullptr);
@@ -73,7 +73,7 @@ void tst_GLShaderManager::adopt()
     QCOMPARE(shaderNodeIds.first(), backendShaderNode1.peerId());
 
     // WHEN
-    Qt3DRender::Render::GLShader *glShader2 = cache.createOrAdoptExisting(&backendShaderNode2);
+    Qt3DRender::Render::OpenGL::GLShader *glShader2 = cache.createOrAdoptExisting(&backendShaderNode2);
 
     // THEN
     QCOMPARE(glShader1, glShader2);
@@ -87,7 +87,7 @@ void tst_GLShaderManager::adopt()
 void tst_GLShaderManager::lookupResource()
 {
     // GIVEN
-    Qt3DRender::Render::GLShaderManager cache;
+    Qt3DRender::Render::OpenGL::GLShaderManager cache;
     Qt3DRender::QShaderProgram frontendShader1;
     Qt3DRender::QShaderProgram frontendShader2;
     TestRenderer renderer;
@@ -104,8 +104,8 @@ void tst_GLShaderManager::lookupResource()
     cache.createOrAdoptExisting(&backendShaderNode2);
 
     // THEN
-    Qt3DRender::Render::GLShader *glShader1 = cache.lookupResource(backendShaderNode1.peerId());
-    Qt3DRender::Render::GLShader *glShader2 = cache.lookupResource(backendShaderNode2.peerId());
+    Qt3DRender::Render::OpenGL::GLShader *glShader1 = cache.lookupResource(backendShaderNode1.peerId());
+    Qt3DRender::Render::OpenGL::GLShader *glShader2 = cache.lookupResource(backendShaderNode2.peerId());
     QVERIFY(glShader1 != nullptr);
     QCOMPARE(glShader1, glShader2);
     const QVector<Qt3DCore::QNodeId> shaderNodeIds = cache.shaderIdsForProgram(glShader1);
@@ -117,7 +117,7 @@ void tst_GLShaderManager::lookupResource()
 void tst_GLShaderManager::abandon()
 {
     // GIVEN
-    Qt3DRender::Render::GLShaderManager cache;
+    Qt3DRender::Render::OpenGL::GLShaderManager cache;
     Qt3DRender::QShaderProgram frontendShader1;
     Qt3DRender::QShaderProgram frontendShader2;
     TestRenderer renderer;
@@ -132,7 +132,7 @@ void tst_GLShaderManager::abandon()
     cache.createOrAdoptExisting(&backendShaderNode2);
 
     // WHEN
-    Qt3DRender::Render::GLShader *glShader = cache.lookupResource(backendShaderNode1.peerId());
+    Qt3DRender::Render::OpenGL::GLShader *glShader = cache.lookupResource(backendShaderNode1.peerId());
     cache.abandon(glShader, &backendShaderNode1);
 
     // THEN
@@ -147,7 +147,7 @@ void tst_GLShaderManager::abandon()
     // THEN
     shaderNodeIds = cache.shaderIdsForProgram(glShader);
     QCOMPARE(shaderNodeIds.size(), 0);
-    const QVector<Qt3DRender::Render::GLShader *> releasedShaders = cache.takeAbandonned();
+    const QVector<Qt3DRender::Render::OpenGL::GLShader *> releasedShaders = cache.takeAbandonned();
     QCOMPARE(releasedShaders.size(), 1);
     QCOMPARE(releasedShaders.first(), glShader);
 }
@@ -155,7 +155,7 @@ void tst_GLShaderManager::abandon()
 void tst_GLShaderManager::insertAfterRemoval()
 {
     // GIVEN
-    Qt3DRender::Render::GLShaderManager cache;
+    Qt3DRender::Render::OpenGL::GLShaderManager cache;
     Qt3DRender::QShaderProgram frontendShader;
     TestRenderer renderer;
     Qt3DRender::Render::Shader backendShaderNode;
@@ -165,8 +165,8 @@ void tst_GLShaderManager::insertAfterRemoval()
     simulateInitialization(&frontendShader, &backendShaderNode);
 
     // WHEN
-    Qt3DRender::Render::GLShader *apiShader1 = cache.createOrAdoptExisting(&backendShaderNode);
-    const Qt3DRender::Render::GLShader *originalApiShader = apiShader1;
+    Qt3DRender::Render::OpenGL::GLShader *apiShader1 = cache.createOrAdoptExisting(&backendShaderNode);
+    const Qt3DRender::Render::OpenGL::GLShader *originalApiShader = apiShader1;
 
     // THEN
     auto apiShader2 = cache.lookupResource(frontendShader.id());
@@ -179,7 +179,7 @@ void tst_GLShaderManager::insertAfterRemoval()
     cache.abandon(apiShader1, &backendShaderNode);
 
     // THEN
-    Qt3DRender::Render::GLShader *apiShaderEmpty = cache.lookupResource(frontendShader.id());
+    Qt3DRender::Render::OpenGL::GLShader *apiShaderEmpty = cache.lookupResource(frontendShader.id());
     QVERIFY(apiShaderEmpty == nullptr);
 
     // WHEN

--- a/tests/auto/render/opengl/graphicshelpergl2/tst_graphicshelpergl2.cpp
+++ b/tests/auto/render/opengl/graphicshelpergl2/tst_graphicshelpergl2.cpp
@@ -47,6 +47,7 @@ QT_BEGIN_NAMESPACE
 
 using namespace Qt3DRender;
 using namespace Qt3DRender::Render;
+using namespace Qt3DRender::Render::OpenGL;
 
 namespace {
 

--- a/tests/auto/render/opengl/graphicshelpergl3_2/tst_graphicshelpergl3_2.cpp
+++ b/tests/auto/render/opengl/graphicshelpergl3_2/tst_graphicshelpergl3_2.cpp
@@ -43,6 +43,7 @@
 
 using namespace Qt3DRender;
 using namespace Qt3DRender::Render;
+using namespace Qt3DRender::Render::OpenGL;
 
 namespace {
 

--- a/tests/auto/render/opengl/graphicshelpergl3_3/tst_graphicshelpergl3_3.cpp
+++ b/tests/auto/render/opengl/graphicshelpergl3_3/tst_graphicshelpergl3_3.cpp
@@ -42,6 +42,7 @@
 
 using namespace Qt3DRender;
 using namespace Qt3DRender::Render;
+using namespace Qt3DRender::Render::OpenGL;
 
 namespace {
 

--- a/tests/auto/render/opengl/graphicshelpergl4/tst_graphicshelpergl4.cpp
+++ b/tests/auto/render/opengl/graphicshelpergl4/tst_graphicshelpergl4.cpp
@@ -43,6 +43,7 @@
 
 using namespace Qt3DRender;
 using namespace Qt3DRender::Render;
+using namespace Qt3DRender::Render::OpenGL;
 
 namespace {
 

--- a/tests/auto/render/opengl/materialparametergathererjob/tst_materialparametergathererjob.cpp
+++ b/tests/auto/render/opengl/materialparametergathererjob/tst_materialparametergathererjob.cpp
@@ -95,9 +95,9 @@ public:
         d_func()->m_renderer->initialize();
     }
 
-    Render::MaterialParameterGathererJobPtr materialGathererJob() const
+    Render::OpenGL::MaterialParameterGathererJobPtr materialGathererJob() const
     {
-        Render::MaterialParameterGathererJobPtr job = Render::MaterialParameterGathererJobPtr::create();
+        Render::OpenGL::MaterialParameterGathererJobPtr job = Render::OpenGL::MaterialParameterGathererJobPtr::create();
         job->setNodeManagers(nodeManagers());
         return job;
     }
@@ -220,7 +220,7 @@ private Q_SLOTS:
         // GIVEN
         Qt3DCore::QEntity *sceneRoot = buildScene(viewportFrameGraph());
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 
@@ -240,7 +240,7 @@ private Q_SLOTS:
         TestMaterial material;
         Qt3DCore::QEntity *sceneRoot = buildScene(viewportFrameGraph(), &material);
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 
@@ -262,7 +262,7 @@ private Q_SLOTS:
         material.setEnabled(false);
         Qt3DCore::QEntity *sceneRoot = buildScene(viewportFrameGraph(), &material);
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 
@@ -294,7 +294,7 @@ private Q_SLOTS:
 
         Qt3DCore::QEntity *sceneRoot = buildScene(frameGraphFilter, &material);
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 
@@ -334,7 +334,7 @@ private Q_SLOTS:
 
         Qt3DCore::QEntity *sceneRoot = buildScene(frameGraphFilter, &material);
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 
@@ -370,7 +370,7 @@ private Q_SLOTS:
 
         Qt3DCore::QEntity *sceneRoot = buildScene(frameGraphFilter, &material);
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 
@@ -404,7 +404,7 @@ private Q_SLOTS:
 
         Qt3DCore::QEntity *sceneRoot = buildScene(frameGraphFilter, &material);
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 
@@ -444,7 +444,7 @@ private Q_SLOTS:
 
         Qt3DCore::QEntity *sceneRoot = buildScene(frameGraphFilter, &material);
         Qt3DRender::TestAspect testAspect(sceneRoot);
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatherer = testAspect.materialGathererJob();
 
         testAspect.initializeRenderer();
 

--- a/tests/auto/render/opengl/qgraphicsutils/tst_qgraphicsutils.cpp
+++ b/tests/auto/render/opengl/qgraphicsutils/tst_qgraphicsutils.cpp
@@ -44,14 +44,14 @@ private slots:
 
 void tst_QGraphicsUtils::fillScalarInDataArray()
 {
-    Qt3DRender::Render::ShaderUniform description;
+    Qt3DRender::Render::OpenGL::ShaderUniform description;
 
     description.m_size = 1;
     description.m_offset = 0;
     description.m_arrayStride = 10;
 
     QVector4D testVector(8.0f, 8.0f, 3.0f, 1.0f);
-    const GLfloat *vectorData = Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(testVector, 1, 4);
+    const GLfloat *vectorData = Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(testVector, 1, 4);
 
     for (int i = 0; i < 4; i++) {
         if (i == 0)
@@ -68,7 +68,7 @@ void tst_QGraphicsUtils::fillScalarInDataArray()
     char *innerData = data.data();
 
     // Checked that we are not overflowing
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 2);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 2);
     for (int i = 0; i < 4; ++i) {
         if (i < 2)
             QVERIFY(vectorData[i] == ((GLfloat*)innerData)[i]);
@@ -77,7 +77,7 @@ void tst_QGraphicsUtils::fillScalarInDataArray()
     }
 
     // Check that all values are copied
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 4);
     for (int i = 0; i < 4; ++i)
         QVERIFY(vectorData[i] == ((GLfloat*)innerData)[i]);
 
@@ -86,7 +86,7 @@ void tst_QGraphicsUtils::fillScalarInDataArray()
     data = QByteArray(description.m_size * 8 * sizeof(GLfloat), 0);
     innerData = data.data();
 
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 4);
     for (int i = 0; i < 8; ++i) {
         if (i < 4)
             QVERIFY(((GLfloat*)innerData)[i] == 0.0f);
@@ -102,9 +102,9 @@ void tst_QGraphicsUtils::fillArray()
     QVector4D testVector3(4.0f, 5.0f, 4.0f, 2.0f);
 
     QVariantList variantList = QVariantList() << testVector << testVector2 << testVector3;
-    const GLfloat *vectorData = Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant(variantList), 3, 4);
+    const GLfloat *vectorData = Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant(variantList), 3, 4);
 
-    Qt3DRender::Render::ShaderUniform description;
+    Qt3DRender::Render::OpenGL::ShaderUniform description;
 
     description.m_size = 3;
     description.m_offset = 16;
@@ -112,7 +112,7 @@ void tst_QGraphicsUtils::fillArray()
 
     QByteArray data(description.m_size * (4 + description.m_arrayStride) * sizeof(GLfloat) + description.m_offset, 0);
     char *innerData = data.data();
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData, vectorData, description, 4);
 
     int offset = description.m_offset / sizeof(GLfloat);
     int stride = description.m_arrayStride / sizeof(GLfloat);
@@ -144,25 +144,25 @@ void tst_QGraphicsUtils::fillScalarWithOffsets()
     QVector4D color(4.0f, 5.0f, 4.0f, 1.0f);
     float intensity = 1.0f;
 
-    Qt3DRender::Render::ShaderUniform posUniform;
+    Qt3DRender::Render::OpenGL::ShaderUniform posUniform;
     posUniform.m_size = 1;
     posUniform.m_arrayStride = 0;
     posUniform.m_matrixStride = 0;
     posUniform.m_offset = 0;
 
-    Qt3DRender::Render::ShaderUniform dirUniform;
+    Qt3DRender::Render::OpenGL::ShaderUniform dirUniform;
     dirUniform.m_size = 1;
     dirUniform.m_arrayStride = 0;
     dirUniform.m_matrixStride = 0;
     dirUniform.m_offset = 16;
 
-    Qt3DRender::Render::ShaderUniform colUniform;
+    Qt3DRender::Render::OpenGL::ShaderUniform colUniform;
     colUniform.m_size = 1;
     colUniform.m_arrayStride = 0;
     colUniform.m_matrixStride = 0;
     colUniform.m_offset = 32;
 
-    Qt3DRender::Render::ShaderUniform intUniform;
+    Qt3DRender::Render::OpenGL::ShaderUniform intUniform;
     intUniform.m_size = 1;
     intUniform.m_arrayStride = 0;
     intUniform.m_matrixStride = 0;
@@ -171,18 +171,18 @@ void tst_QGraphicsUtils::fillScalarWithOffsets()
     QVector<GLfloat> data(16);
     void *innerData = data.data();
 
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData,
-                                                Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(position, 1, 3),
-                                                posUniform, 3);
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData,
-                                                Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(direction, 1, 3),
-                                                dirUniform, 3);
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData,
-                                                Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(color, 1, 4),
-                                                colUniform, 4);
-    Qt3DRender::Render::QGraphicsUtils::fillDataArray(innerData,
-                                                Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(intensity, 1, 1),
-                                                intUniform, 1);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData,
+                                                              Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(position, 1, 3),
+                                                              posUniform, 3);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData,
+                                                              Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(direction, 1, 3),
+                                                              dirUniform, 3);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData,
+                                                              Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(color, 1, 4),
+                                                              colUniform, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataArray(innerData,
+                                                              Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(intensity, 1, 1),
+                                                              intUniform, 1);
 
     GLfloat *floatData = (GLfloat*)innerData;
 
@@ -214,9 +214,9 @@ void tst_QGraphicsUtils::fillMatrix4x4()
     QMatrix4x4 mat(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f);
 
     // column major
-    const GLfloat *matData = Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(mat, 1, 16);
+    const GLfloat *matData = Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(mat, 1, 16);
 
-    Qt3DRender::Render::ShaderUniform description;
+    Qt3DRender::Render::OpenGL::ShaderUniform description;
 
     description.m_size = 1;
     description.m_offset = 0;
@@ -226,7 +226,7 @@ void tst_QGraphicsUtils::fillMatrix4x4()
 
     QByteArray data(description.m_size * 16 * sizeof(GLfloat), 0);
     char *innerData = data.data();
-    Qt3DRender::Render::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 4);
     // Check for no offset/no stride
     for (int i = 0; i < 16; ++i)
         QVERIFY((((GLfloat *)innerData)[i]) == matData[i]);
@@ -234,7 +234,7 @@ void tst_QGraphicsUtils::fillMatrix4x4()
     description.m_offset = 12;
     data = QByteArray((description.m_size * 16  + description.m_offset) * sizeof(GLfloat), 0);
     innerData = data.data();
-    Qt3DRender::Render::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 4);
     // Check with 12 offset/no stride
     for (int i = 0; i < 16; ++i)
         QVERIFY((((GLfloat *)innerData)[3 + i]) == matData[i]);
@@ -242,7 +242,7 @@ void tst_QGraphicsUtils::fillMatrix4x4()
     description.m_matrixStride = 16;
     data = QByteArray((description.m_size * 16 + 4 * description.m_matrixStride + description.m_offset) * sizeof(GLfloat), 0);
     innerData = data.data();
-    Qt3DRender::Render::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 4);
     // Check with 10 offset/ 16 stride
     int offset = description.m_offset / sizeof(GLfloat);
     int matrixStride = description.m_matrixStride / sizeof(GLfloat);
@@ -259,9 +259,9 @@ void tst_QGraphicsUtils::fillMatrix3x4()
     QMatrix3x4 mat;
 
     mat.fill(6.0f);
-    const GLfloat *matData = Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant::fromValue(mat), 1, 12);
+    const GLfloat *matData = Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant::fromValue(mat), 1, 12);
 
-    Qt3DRender::Render::ShaderUniform description;
+    Qt3DRender::Render::OpenGL::ShaderUniform description;
 
     description.m_size = 1;
     description.m_offset = 16;
@@ -270,7 +270,7 @@ void tst_QGraphicsUtils::fillMatrix3x4()
 
     QByteArray data((description.m_size * 12 + 3 * description.m_matrixStride + description.m_offset) * sizeof(GLfloat), 0);
     char *innerData = data.data();
-    Qt3DRender::Render::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 3, 4);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 3, 4);
     // Check with 16 offset/ 12 stride
     int offset = description.m_offset / sizeof(GLfloat);
     int matrixStride = description.m_matrixStride / sizeof(GLfloat);
@@ -287,9 +287,9 @@ void tst_QGraphicsUtils::fillMatrix4x3()
     QMatrix4x3 mat;
 
     mat.fill(6.0f);
-    const GLfloat *matData = Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant::fromValue(mat), 1, 12);
+    const GLfloat *matData = Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant::fromValue(mat), 1, 12);
 
-    Qt3DRender::Render::ShaderUniform description;
+    Qt3DRender::Render::OpenGL::ShaderUniform description;
 
     description.m_size = 1;
     description.m_offset = 16;
@@ -298,7 +298,7 @@ void tst_QGraphicsUtils::fillMatrix4x3()
 
     QByteArray data((description.m_size * 12 + 4 * description.m_matrixStride + description.m_offset) * sizeof(GLfloat), 0);
     char *innerData = data.data();
-    Qt3DRender::Render::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 3);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 3);
     // Check with 16 offset/ 16 stride
     int offset = description.m_offset / sizeof(GLfloat);
     int matrixStride = description.m_matrixStride / sizeof(GLfloat);
@@ -321,9 +321,9 @@ void tst_QGraphicsUtils::fillMatrixArray()
 
     QVariantList matrices = QVariantList() << QVariant::fromValue(mat1) << QVariant::fromValue(mat2) << QVariant::fromValue(mat3);
 
-    const GLfloat *matData = Qt3DRender::Render::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant::fromValue(matrices), 3, 12);
+    const GLfloat *matData = Qt3DRender::Render::OpenGL::QGraphicsUtils::valueArrayFromVariant<GLfloat>(QVariant::fromValue(matrices), 3, 12);
 
-    Qt3DRender::Render::ShaderUniform description;
+    Qt3DRender::Render::OpenGL::ShaderUniform description;
 
     description.m_size = 3;
     description.m_offset = 12;
@@ -332,7 +332,7 @@ void tst_QGraphicsUtils::fillMatrixArray()
 
     QByteArray data((description.m_size * (12 + 4 * description.m_matrixStride + description.m_arrayStride) + description.m_offset) * sizeof(GLfloat), 0);
     char *innerData = data.data();
-    Qt3DRender::Render::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 3);
+    Qt3DRender::Render::OpenGL::QGraphicsUtils::fillDataMatrixArray(innerData, matData, description, 4, 3);
     // Check with 12 offset/ 4 array stride / 16 matrix stride
     int offset = description.m_offset / sizeof(GLfloat);
     int matrixStride = description.m_matrixStride / sizeof(GLfloat);

--- a/tests/auto/render/opengl/renderer/tst_renderer.cpp
+++ b/tests/auto/render/opengl/renderer/tst_renderer.cpp
@@ -48,7 +48,7 @@ private Q_SLOTS:
     {
         // GIVEN
         Qt3DRender::Render::NodeManagers nodeManagers;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Qt3DRender::Render::OpenGL::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         Qt3DRender::Render::OffscreenSurfaceHelper offscreenHelper(&renderer);
         Qt3DRender::Render::RenderSettings settings;
         // owned by FG manager
@@ -69,7 +69,7 @@ private Q_SLOTS:
         // NOTE: FilterCompatibleTechniqueJob and ShaderGathererJob cannot run because the context
         // is not initialized in this test
 
-        const int singleRenderViewJobCount = 11 + 1 * Qt3DRender::Render::RenderViewBuilder::optimalJobCount();
+        const int singleRenderViewJobCount = 11 + 1 * Qt3DRender::Render::OpenGL::RenderViewBuilder::optimalJobCount();
         // RenderViewBuilder renderViewJob,
         //                   renderableEntityFilterJob,
         //                   lightGatherJob,

--- a/tests/auto/render/opengl/renderqueue/tst_renderqueue.cpp
+++ b/tests/auto/render/opengl/renderqueue/tst_renderqueue.cpp
@@ -53,7 +53,7 @@ private Q_SLOTS:
 void tst_RenderQueue::setRenderViewCount()
 {
     // GIVEN
-    Qt3DRender::Render::RenderQueue renderQueue;
+    Qt3DRender::Render::OpenGL::RenderQueue renderQueue;
 
     // THEN
     QCOMPARE(renderQueue.wasReset(), true);
@@ -70,7 +70,7 @@ void tst_RenderQueue::setRenderViewCount()
 void tst_RenderQueue::circleQueues()
 {
     // GIVEN
-    Qt3DRender::Render::RenderQueue renderQueue;
+    Qt3DRender::Render::OpenGL::RenderQueue renderQueue;
     renderQueue.setTargetRenderViewCount(7);
 
     // WHEN
@@ -85,9 +85,9 @@ void tst_RenderQueue::circleQueues()
         QCOMPARE(renderQueue.currentRenderViewCount(), 0);
 
         // WHEN
-        QList<Qt3DRender::Render::RenderView *> renderViews;
+        QList<Qt3DRender::Render::OpenGL::RenderView *> renderViews;
         for (int i = 0; i < 7; i++) {
-            renderViews << new Qt3DRender::Render::RenderView();
+            renderViews << new Qt3DRender::Render::OpenGL::RenderView();
             renderQueue.queueRenderView(renderViews.at(i), i);
         }
 
@@ -99,19 +99,19 @@ void tst_RenderQueue::circleQueues()
 void tst_RenderQueue::checkOrder()
 {
     // GIVEN
-    Qt3DRender::Render::RenderQueue renderQueue;
+    Qt3DRender::Render::OpenGL::RenderQueue renderQueue;
     renderQueue.setTargetRenderViewCount(7);
-    QVector<Qt3DRender::Render::RenderView *> renderViews(7);
+    QVector<Qt3DRender::Render::OpenGL::RenderView *> renderViews(7);
 
     // WHEN
     for (int i = 0; i < 7; ++i) {
         int processingOrder = (i % 2 == 0) ? (6 - i) : i;
-        renderViews[processingOrder] = new Qt3DRender::Render::RenderView();
+        renderViews[processingOrder] = new Qt3DRender::Render::OpenGL::RenderView();
         renderQueue.queueRenderView(renderViews[processingOrder], processingOrder);
     }
 
     // THEN
-    QVector<Qt3DRender::Render::RenderView *> frame = renderQueue.nextFrameQueue();
+    QVector<Qt3DRender::Render::OpenGL::RenderView *> frame = renderQueue.nextFrameQueue();
     for (int i = 0; i < 7; ++i) {
         QVERIFY(frame[i] == renderViews[i]);
     }
@@ -120,14 +120,14 @@ void tst_RenderQueue::checkOrder()
 void tst_RenderQueue::checkTimeToSubmit()
 {
     // GIVEN
-    Qt3DRender::Render::RenderQueue renderQueue;
+    Qt3DRender::Render::OpenGL::RenderQueue renderQueue;
     renderQueue.setTargetRenderViewCount(7);
-    QVector<Qt3DRender::Render::RenderView *> renderViews(7);
+    QVector<Qt3DRender::Render::OpenGL::RenderView *> renderViews(7);
 
     // WHEN
     for (int i = 0; i < 7; i++) {
         int processingOrder = (i % 2 == 0) ? (6 - i) : i;
-        renderViews[processingOrder] = new Qt3DRender::Render::RenderView();
+        renderViews[processingOrder] = new Qt3DRender::Render::OpenGL::RenderView();
         renderQueue.queueRenderView(renderViews[processingOrder], processingOrder);
 
         // THEN
@@ -144,7 +144,7 @@ class SimpleWorker : public QThread
 public:
     QSemaphore m_waitSubmit;
     QSemaphore m_waitQueue;
-    Qt3DRender::Render::RenderQueue *m_renderQueues;
+    Qt3DRender::Render::OpenGL::RenderQueue *m_renderQueues;
 
 public Q_SLOTS:
 
@@ -160,7 +160,7 @@ public Q_SLOTS:
                 // THEN
                 QCOMPARE(m_renderQueues->currentRenderViewCount(), j);
                 // WHEN
-                m_renderQueues->queueRenderView(new Qt3DRender::Render::RenderView(), j);
+                m_renderQueues->queueRenderView(new Qt3DRender::Render::OpenGL::RenderView(), j);
                 // THEN
                 QVERIFY(m_renderQueues->targetRenderViewCount() == 7);
                 QCOMPARE(m_renderQueues->currentRenderViewCount(), j + 1);
@@ -178,7 +178,7 @@ public Q_SLOTS:
 void tst_RenderQueue::concurrentQueueAccess()
 {
     // GIVEN
-    Qt3DRender::Render::RenderQueue *renderQueue = new Qt3DRender::Render::RenderQueue;
+    Qt3DRender::Render::OpenGL::RenderQueue *renderQueue = new Qt3DRender::Render::OpenGL::RenderQueue;
 
     SimpleWorker *jobsThread = new SimpleWorker();
     renderQueue->setTargetRenderViewCount(7);
@@ -212,7 +212,7 @@ void tst_RenderQueue::concurrentQueueAccess()
 void tst_RenderQueue::resetQueue()
 {
     // GIVEN
-    Qt3DRender::Render::RenderQueue renderQueue;
+    Qt3DRender::Render::OpenGL::RenderQueue renderQueue;
 
     for (int j = 0; j < 5; j++) {
         // WHEN
@@ -222,7 +222,7 @@ void tst_RenderQueue::resetQueue()
         QVERIFY(renderQueue.currentRenderViewCount() == 0);
 
         // WHEN
-        QVector<Qt3DRender::Render::RenderView *> renderViews(5);
+        QVector<Qt3DRender::Render::OpenGL::RenderView *> renderViews(5);
         for (int i = 0; i < 5; ++i) {
             renderQueue.queueRenderView(renderViews.at(i), i);
         }

--- a/tests/auto/render/opengl/renderviewbuilder/tst_renderviewbuilder.cpp
+++ b/tests/auto/render/opengl/renderviewbuilder/tst_renderviewbuilder.cpp
@@ -81,14 +81,14 @@ public:
         return d_func()->m_renderer->nodeManagers();
     }
 
-    Render::Renderer *renderer() const
+    Render::OpenGL::Renderer *renderer() const
     {
-        return static_cast<Render::Renderer *>(d_func()->m_renderer);
+        return static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer);
     }
 
-    Render::MaterialParameterGathererJobPtr materialGathererJob() const
+    Render::OpenGL::MaterialParameterGathererJobPtr materialGathererJob() const
     {
-        Render::MaterialParameterGathererJobPtr job = Render::MaterialParameterGathererJobPtr::create();
+        Render::OpenGL::MaterialParameterGathererJobPtr job = Render::OpenGL::MaterialParameterGathererJobPtr::create();
         job->setNodeManagers(nodeManagers());
         return job;
     }
@@ -180,7 +180,7 @@ private Q_SLOTS:
 
         {
             // WHEN
-            Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+            Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
 
             // THEN
             QCOMPARE(renderViewBuilder.renderViewIndex(), 0);
@@ -214,14 +214,14 @@ private Q_SLOTS:
             QVERIFY(renderViewBuilder.filterEntityByLayerJob().isNull());
             QVERIFY(renderViewBuilder.syncFilterEntityByLayerJob().isNull());
 
-            QCOMPARE(renderViewBuilder.renderViewBuilderJobs().size(), Qt3DRender::Render::RenderViewBuilder::optimalJobCount());
+            QCOMPARE(renderViewBuilder.renderViewBuilderJobs().size(), Qt3DRender::Render::OpenGL::RenderViewBuilder::optimalJobCount());
             QCOMPARE(renderViewBuilder.materialGathererJobs().size(), 0);
-            QCOMPARE(renderViewBuilder.buildJobHierachy().size(), 11 + 1 * Qt3DRender::Render::RenderViewBuilder::optimalJobCount());
+            QCOMPARE(renderViewBuilder.buildJobHierachy().size(), 11 + 1 * Qt3DRender::Render::OpenGL::RenderViewBuilder::optimalJobCount());
         }
 
         {
             // WHEN
-            Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+            Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
             renderViewBuilder.setLayerCacheNeedsToBeRebuilt(true);
             renderViewBuilder.prepareJobs();
 
@@ -231,22 +231,22 @@ private Q_SLOTS:
             QVERIFY(!renderViewBuilder.syncFilterEntityByLayerJob().isNull());
 
             // mark jobs dirty and recheck
-            QCOMPARE(renderViewBuilder.buildJobHierachy().size(), 13 + 1 * Qt3DRender::Render::RenderViewBuilder::optimalJobCount());
+            QCOMPARE(renderViewBuilder.buildJobHierachy().size(), 13 + 1 * Qt3DRender::Render::OpenGL::RenderViewBuilder::optimalJobCount());
         }
 
         {
             // WHEN
-            Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+            Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
             renderViewBuilder.setMaterialGathererCacheNeedsToBeRebuilt(true);
             renderViewBuilder.prepareJobs();
 
             // THEN
             QCOMPARE(renderViewBuilder.materialGathererCacheNeedsToBeRebuilt(), true);
-            QCOMPARE(renderViewBuilder.materialGathererJobs().size(), Qt3DRender::Render::RenderViewBuilder::optimalJobCount());
+            QCOMPARE(renderViewBuilder.materialGathererJobs().size(), Qt3DRender::Render::OpenGL::RenderViewBuilder::optimalJobCount());
             QVERIFY(!renderViewBuilder.syncMaterialGathererJob().isNull());
 
             // mark jobs dirty and recheck
-            QCOMPARE(renderViewBuilder.buildJobHierachy().size(), 12 + 2 * Qt3DRender::Render::RenderViewBuilder::optimalJobCount());
+            QCOMPARE(renderViewBuilder.buildJobHierachy().size(), 12 + 2 * Qt3DRender::Render::OpenGL::RenderViewBuilder::optimalJobCount());
         }
     }
 
@@ -263,7 +263,7 @@ private Q_SLOTS:
 
         {
             // WHEN
-            Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+            Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
             renderViewBuilder.prepareJobs();
             renderViewBuilder.buildJobHierachy();
 
@@ -335,7 +335,7 @@ private Q_SLOTS:
         }
         {
             // WHEN
-            Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+            Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
             renderViewBuilder.setLayerCacheNeedsToBeRebuilt(true);
             renderViewBuilder.prepareJobs();
             renderViewBuilder.buildJobHierachy();
@@ -423,7 +423,7 @@ private Q_SLOTS:
         QVERIFY(leafNode != nullptr);
 
         // WHEN
-        Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+        Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
         renderViewBuilder.prepareJobs();
         renderViewBuilder.buildJobHierachy();
         renderViewBuilder.renderViewJob()->run();
@@ -444,7 +444,7 @@ private Q_SLOTS:
         QVERIFY(leafNode != nullptr);
 
         // WHEN
-        Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+        Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
         renderViewBuilder.prepareJobs();
         renderViewBuilder.buildJobHierachy();
         renderViewBuilder.renderableEntityFilterJob()->run();
@@ -465,7 +465,7 @@ private Q_SLOTS:
         QVERIFY(leafNode != nullptr);
 
         // WHEN
-        Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+        Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
         renderViewBuilder.prepareJobs();
         renderViewBuilder.buildJobHierachy();
         renderViewBuilder.computableEntityFilterJob()->run();
@@ -494,7 +494,7 @@ private Q_SLOTS:
 
         {
             // WHEN
-            Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+            Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
             renderViewBuilder.prepareJobs();
             renderViewBuilder.buildJobHierachy();
 
@@ -518,7 +518,7 @@ private Q_SLOTS:
         }
         {
             // WHEN
-            Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+            Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
             renderViewBuilder.setLayerCacheNeedsToBeRebuilt(true);
             renderViewBuilder.prepareJobs();
             renderViewBuilder.buildJobHierachy();
@@ -564,7 +564,7 @@ private Q_SLOTS:
         QVERIFY(leafNode != nullptr);
 
         // WHEN
-        Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+        Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
         renderViewBuilder.prepareJobs();
         renderViewBuilder.buildJobHierachy();
 
@@ -594,7 +594,7 @@ private Q_SLOTS:
         QVERIFY(leafNode != nullptr);
 
         // WHEN
-        Qt3DRender::Render::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
+        Qt3DRender::Render::OpenGL::RenderViewBuilder renderViewBuilder(leafNode, 0, testAspect.renderer());
         renderViewBuilder.setLayerCacheNeedsToBeRebuilt(true);
         renderViewBuilder.prepareJobs();
         renderViewBuilder.buildJobHierachy();
@@ -614,7 +614,7 @@ private Q_SLOTS:
         std::sort(renderableEntity.begin(), renderableEntity.end());
 
         // WHEN
-        renderableEntity = Qt3DRender::Render::RenderViewBuilder::entitiesInSubset(renderableEntity, filteredEntity);
+        renderableEntity = Qt3DRender::Render::OpenGL::RenderViewBuilder::entitiesInSubset(renderableEntity, filteredEntity);
 
         // THEN
         QCOMPARE(renderableEntity.size(), 100);

--- a/tests/auto/render/opengl/renderviews/tst_renderviews.cpp
+++ b/tests/auto/render/opengl/renderviews/tst_renderviews.cpp
@@ -47,6 +47,8 @@ namespace Qt3DRender {
 
 namespace Render {
 
+namespace OpenGL {
+
 namespace {
 
 void compareShaderParameterPacks(const ShaderParameterPack &t1,
@@ -129,7 +131,7 @@ private Q_SLOTS:
             QCOMPARE(backendBarrier.waitOperations(), barriers);
 
             // WHEN
-            Qt3DRender::Render::setRenderViewConfigFromFrameGraphLeafNode(&renderView, &backendBarrier);
+            Qt3DRender::Render::OpenGL::setRenderViewConfigFromFrameGraphLeafNode(&renderView, &backendBarrier);
 
             // THEN
             QCOMPARE(backendBarrier.waitOperations(), renderView.memoryBarrier());
@@ -141,7 +143,7 @@ private Q_SLOTS:
     {
         // GIVEN
         Qt3DRender::Render::NodeManagers nodeManagers;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         RenderView renderView;
         QVector<RenderCommand *> rawCommands;
         QVector<QSortPolicy::SortType> sortTypes;
@@ -175,7 +177,7 @@ private Q_SLOTS:
     {
         // GIVEN
         Qt3DRender::Render::NodeManagers nodeManagers;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         RenderView renderView;
         QVector<RenderCommand *> rawCommands;
         QVector<QSortPolicy::SortType> sortTypes;
@@ -266,7 +268,7 @@ private Q_SLOTS:
         QFETCH(QVector<ShaderParameterPack>, expectedMinimizedParameters);
 
         Qt3DRender::Render::NodeManagers nodeManagers;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         renderer.setNodeManagers(&nodeManagers);
 
         GLShaderManager *shaderManager = renderer.glResourceManagers()->glShaderManager();
@@ -308,7 +310,7 @@ private Q_SLOTS:
     {
         // GIVEN
         Qt3DRender::Render::NodeManagers nodeManagers;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         RenderView renderView;
         QVector<RenderCommand *> rawCommands;
         QVector<QSortPolicy::SortType> sortTypes;
@@ -342,7 +344,7 @@ private Q_SLOTS:
     {
         // GIVEN
         Qt3DRender::Render::NodeManagers nodeManagers;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         RenderView renderView;
         QVector<RenderCommand *> rawCommands;
         QVector<QSortPolicy::SortType> sortTypes;
@@ -376,7 +378,7 @@ private Q_SLOTS:
     {
         // GIVEN
         Qt3DRender::Render::NodeManagers nodeManagers;
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         RenderView renderView;
         QVector<RenderCommand *> rawCommands;
         QVector<QSortPolicy::SortType> sortTypes;
@@ -460,6 +462,8 @@ private Q_SLOTS:
 private:
 };
 
+} // OpenGL
+
 } // Render
 
 } // Qt3DRender
@@ -467,6 +471,6 @@ private:
 QT_END_NAMESPACE
 
 //APPLESS_
-QTEST_MAIN(Qt3DRender::Render::tst_RenderViews)
+QTEST_MAIN(Qt3DRender::Render::OpenGL::tst_RenderViews)
 
 #include "tst_renderviews.moc"

--- a/tests/auto/render/opengl/renderviewutils/tst_renderviewutils.cpp
+++ b/tests/auto/render/opengl/renderviewutils/tst_renderviewutils.cpp
@@ -106,11 +106,11 @@ public:
         return m_scalar;
     }
 
-    QHash<QString, Qt3DRender::Render::ShaderUniform> buildUniformMap(const QString &blockName)
+    QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> buildUniformMap(const QString &blockName)
     {
-        QHash<QString, Qt3DRender::Render::ShaderUniform> uniforms;
+        QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> uniforms;
 
-        uniforms.insert(blockName + QStringLiteral(".scalar"), Qt3DRender::Render::ShaderUniform());
+        uniforms.insert(blockName + QStringLiteral(".scalar"), Qt3DRender::Render::OpenGL::ShaderUniform());
 
         return uniforms;
     }
@@ -147,11 +147,11 @@ public:
         return m_texture;
     }
 
-    QHash<QString, Qt3DRender::Render::ShaderUniform> buildUniformMap(const QString &blockName)
+    QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> buildUniformMap(const QString &blockName)
     {
-        QHash<QString, Qt3DRender::Render::ShaderUniform> uniforms;
+        QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> uniforms;
 
-        uniforms.insert(blockName + QStringLiteral(".texture"), Qt3DRender::Render::ShaderUniform());
+        uniforms.insert(blockName + QStringLiteral(".texture"), Qt3DRender::Render::OpenGL::ShaderUniform());
 
         return uniforms;
     }
@@ -188,11 +188,11 @@ public:
         return m_array;
     }
 
-    QHash<QString, Qt3DRender::Render::ShaderUniform> buildUniformMap(const QString &blockName)
+    QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> buildUniformMap(const QString &blockName)
     {
-        QHash<QString, Qt3DRender::Render::ShaderUniform> uniforms;
+        QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> uniforms;
 
-        uniforms.insert(blockName + QStringLiteral(".array[0]"), Qt3DRender::Render::ShaderUniform());
+        uniforms.insert(blockName + QStringLiteral(".array[0]"), Qt3DRender::Render::OpenGL::ShaderUniform());
 
         return uniforms;
     }
@@ -243,12 +243,12 @@ public:
         return m_array;
     }
 
-    virtual QHash<QString, Qt3DRender::Render::ShaderUniform> buildUniformMap(const QString &blockName)
+    virtual QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> buildUniformMap(const QString &blockName)
     {
-        QHash<QString, Qt3DRender::Render::ShaderUniform> uniforms;
+        QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> uniforms;
 
-        uniforms.insert(blockName + QStringLiteral(".scalar"), Qt3DRender::Render::ShaderUniform());
-        uniforms.insert(blockName + QStringLiteral(".array[0]"), Qt3DRender::Render::ShaderUniform());
+        uniforms.insert(blockName + QStringLiteral(".scalar"), Qt3DRender::Render::OpenGL::ShaderUniform());
+        uniforms.insert(blockName + QStringLiteral(".array[0]"), Qt3DRender::Render::OpenGL::ShaderUniform());
 
         return uniforms;
     }
@@ -297,17 +297,17 @@ public:
         return m_inner;
     }
 
-    QHash<QString, Qt3DRender::Render::ShaderUniform> buildUniformMap(const QString &blockName) override
+    QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> buildUniformMap(const QString &blockName) override
     {
-        QHash<QString, Qt3DRender::Render::ShaderUniform> innerUniforms;
+        QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> innerUniforms;
 
         StructShaderData *innerData = nullptr;
         if ((innerData = qobject_cast<StructShaderData *>(m_inner)) != nullptr)
             innerUniforms = innerData->buildUniformMap(QStringLiteral(".inner"));
 
-        QHash<QString, Qt3DRender::Render::ShaderUniform> uniforms = StructShaderData::buildUniformMap(blockName);
-        QHash<QString, Qt3DRender::Render::ShaderUniform>::const_iterator it = innerUniforms.begin();
-        const QHash<QString, Qt3DRender::Render::ShaderUniform>::const_iterator end = innerUniforms.end();
+        QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform> uniforms = StructShaderData::buildUniformMap(blockName);
+        QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform>::const_iterator it = innerUniforms.begin();
+        const QHash<QString, Qt3DRender::Render::OpenGL::ShaderUniform>::const_iterator end = innerUniforms.end();
 
         while (it != end) {
             uniforms.insert(blockName + it.key(), it.value());
@@ -359,7 +359,7 @@ void tst_RenderViewUtils::topLevelScalarValueNoUniforms()
     QVERIFY(backendShaderData != nullptr);
 
     // WHEB
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
@@ -387,7 +387,7 @@ void tst_RenderViewUtils::topLevelScalarValue()
     QVERIFY(backendShaderData != nullptr);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
@@ -400,8 +400,8 @@ void tst_RenderViewUtils::topLevelScalarValue()
     QCOMPARE(blockBuilder.activeUniformNamesToValue.count(), 1);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
-    const Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
+    const Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
 
     while (it != end) {
         // THEN
@@ -428,7 +428,7 @@ void tst_RenderViewUtils::topLevelTextureValueNoUniforms()
     QVERIFY(backendShaderData != nullptr);
 
     // WHEB
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
@@ -458,7 +458,7 @@ void tst_RenderViewUtils::topLevelTextureValue()
     QVERIFY(backendShaderData != nullptr);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
@@ -471,8 +471,8 @@ void tst_RenderViewUtils::topLevelTextureValue()
     QCOMPARE(blockBuilder.activeUniformNamesToValue.count(), 1);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
-    const Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
+    const Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
 
     while (it != end) {
         // THEN
@@ -499,7 +499,7 @@ void tst_RenderViewUtils::topLevelArrayValue()
     QVERIFY(backendShaderData != nullptr);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
@@ -512,8 +512,8 @@ void tst_RenderViewUtils::topLevelArrayValue()
     QCOMPARE(blockBuilder.activeUniformNamesToValue.count(), 1);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
-    const Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
+    const Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
 
     while (it != end) {
         // THEN
@@ -563,13 +563,13 @@ void tst_RenderViewUtils::nestedShaderDataValue()
     QVERIFY(backendShaderData3 != nullptr);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
-    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[0].scalar"), Qt3DRender::Render::ShaderUniform());
-    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[1].scalar"), Qt3DRender::Render::ShaderUniform());
-    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[2].scalar"), Qt3DRender::Render::ShaderUniform());
+    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[0].scalar"), Qt3DRender::Render::OpenGL::ShaderUniform());
+    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[1].scalar"), Qt3DRender::Render::OpenGL::ShaderUniform());
+    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[2].scalar"), Qt3DRender::Render::OpenGL::ShaderUniform());
     // build name-value map
     blockBuilder.buildActiveUniformNameValueMapStructHelper(backendArrayShaderData, QStringLiteral("MyBlock"));
 
@@ -638,7 +638,7 @@ void tst_RenderViewUtils::topLevelStructValue()
     QVERIFY(backendShaderData != nullptr);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
@@ -651,8 +651,8 @@ void tst_RenderViewUtils::topLevelStructValue()
     QCOMPARE(blockBuilder.activeUniformNamesToValue.count(), blockBuilder.uniforms.count());
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
-    const Qt3DRender::Render::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator it = blockBuilder.activeUniformNamesToValue.begin();
+    const Qt3DRender::Render::OpenGL::UniformBlockValueBuilderHash::const_iterator end = blockBuilder.activeUniformNamesToValue.end();
 
     while (it != end) {
         // THEN
@@ -683,13 +683,13 @@ void tst_RenderViewUtils::topLevelDynamicProperties()
     QVERIFY(backendShaderData != nullptr);
 
     // WHEN
-    Qt3DRender::Render::UniformBlockValueBuilder blockBuilder;
+    Qt3DRender::Render::OpenGL::UniformBlockValueBuilder blockBuilder;
     blockBuilder.shaderDataManager = manager.data();
     blockBuilder.textureManager = textureManager.data();
     blockBuilder.updatedPropertiesOnly = false;
-    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.scalar"), Qt3DRender::Render::ShaderUniform());
-    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[0]"), Qt3DRender::Render::ShaderUniform());
-    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.texture"), Qt3DRender::Render::ShaderUniform());
+    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.scalar"), Qt3DRender::Render::OpenGL::ShaderUniform());
+    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.array[0]"), Qt3DRender::Render::OpenGL::ShaderUniform());
+    blockBuilder.uniforms.insert(QStringLiteral("MyBlock.texture"), Qt3DRender::Render::OpenGL::ShaderUniform());
     // build name-value map
     blockBuilder.buildActiveUniformNameValueMapStructHelper(backendShaderData, QStringLiteral("MyBlock"));
 

--- a/tests/auto/render/opengl/sendrendercapturejob/tst_sendrendercapturejob.cpp
+++ b/tests/auto/render/opengl/sendrendercapturejob/tst_sendrendercapturejob.cpp
@@ -47,7 +47,7 @@ private Q_SLOTS:
 
         QImage image(10, 10, QImage::Format_ARGB32);
 
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Qt3DRender::Render::OpenGL::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         Qt3DRender::Render::SendRenderCaptureJob job;
 
         Qt3DRender::Render::NodeManagers nodeManagers;

--- a/tests/auto/render/opengl/textures/tst_textures.cpp
+++ b/tests/auto/render/opengl/textures/tst_textures.cpp
@@ -179,7 +179,7 @@ private Q_SLOTS:
     void shouldCreateSameGLTextures()
     {
         QScopedPointer<Qt3DRender::Render::NodeManagers> mgrs(new Qt3DRender::Render::NodeManagers());
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Qt3DRender::Render::OpenGL::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         renderer.setNodeManagers(mgrs.data());
 
         // GIVEN
@@ -206,7 +206,7 @@ private Q_SLOTS:
     void shouldCreateDifferentGLTexturess()
     {
         QScopedPointer<Qt3DRender::Render::NodeManagers> mgrs(new Qt3DRender::Render::NodeManagers());
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Qt3DRender::Render::OpenGL::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         renderer.setNodeManagers(mgrs.data());
 
         // GIVEN
@@ -237,7 +237,7 @@ private Q_SLOTS:
                 QVERIFY(renderer.glResourceManagers()->glTextureManager()->lookupResource(backend[i]->peerId()) !=
                         renderer.glResourceManagers()->glTextureManager()->lookupResource(backend[k]->peerId()));
 
-        QVector<Qt3DRender::Render::GLTexture *> glTextures;
+        QVector<Qt3DRender::Render::OpenGL::GLTexture *> glTextures;
         for (Qt3DRender::Render::Texture *t : backend)
             glTextures.push_back(renderer.glResourceManagers()->glTextureManager()->lookupResource(t->peerId()));
 
@@ -260,7 +260,7 @@ private Q_SLOTS:
     void generatorsShouldCreateSameData()
     {
         QScopedPointer<Qt3DRender::Render::NodeManagers> mgrs(new Qt3DRender::Render::NodeManagers());
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Qt3DRender::Render::OpenGL::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         renderer.setNodeManagers(mgrs.data());
 
         // GIVEN
@@ -525,7 +525,7 @@ private Q_SLOTS:
     void checkTextureImageProperlyReleaseGenerator()
     {
         QScopedPointer<Qt3DRender::Render::NodeManagers> mgrs(new Qt3DRender::Render::NodeManagers());
-        Qt3DRender::Render::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
+        Qt3DRender::Render::OpenGL::Renderer renderer(Qt3DRender::QRenderAspect::Synchronous);
         Qt3DRender::Render::TextureManager *texMgr = mgrs->textureManager();
         Qt3DRender::Render::TextureImageManager *texImgMgr = mgrs->textureImageManager();
         Qt3DRender::Render::TextureImageDataManager *texImgDataMgr = mgrs->textureImageDataManager();

--- a/tests/benchmarks/render/jobs/tst_bench_jobs.cpp
+++ b/tests/benchmarks/render/jobs/tst_bench_jobs.cpp
@@ -88,32 +88,32 @@ namespace Qt3DRender {
 
         QVector<Qt3DCore::QAspectJobPtr> worldTransformJob()
         {
-            static_cast<Render::Renderer *>(d_func()->m_renderer)->m_worldTransformJob->setRoot(d_func()->m_renderer->sceneRoot());
-            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::Renderer *>(d_func()->m_renderer)->m_worldTransformJob;
+            static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_worldTransformJob->setRoot(d_func()->m_renderer->sceneRoot());
+            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_worldTransformJob;
         }
 
         QVector<Qt3DCore::QAspectJobPtr> updateBoundingJob()
         {
-            static_cast<Render::Renderer *>(d_func()->m_renderer)->m_updateWorldBoundingVolumeJob->setManager(d_func()->m_renderer->nodeManagers()->renderNodesManager());
-            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::Renderer *>(d_func()->m_renderer)->m_updateWorldBoundingVolumeJob;
+            static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_updateWorldBoundingVolumeJob->setManager(d_func()->m_renderer->nodeManagers()->renderNodesManager());
+            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_updateWorldBoundingVolumeJob;
         }
 
         QVector<Qt3DCore::QAspectJobPtr> calculateBoundingVolumeJob()
         {
-            static_cast<Render::Renderer *>(d_func()->m_renderer)->m_calculateBoundingVolumeJob->setRoot(d_func()->m_renderer->sceneRoot());
-            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::Renderer *>(d_func()->m_renderer)->m_calculateBoundingVolumeJob;
+            static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_calculateBoundingVolumeJob->setRoot(d_func()->m_renderer->sceneRoot());
+            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_calculateBoundingVolumeJob;
         }
 
         QVector<Qt3DCore::QAspectJobPtr> framePreparationJob()
         {
-            static_cast<Render::Renderer *>(d_func()->m_renderer)->m_updateShaderDataTransformJob->setManagers(d_func()->m_renderer->nodeManagers());
-            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::Renderer *>(d_func()->m_renderer)->m_updateShaderDataTransformJob;
+            static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_updateShaderDataTransformJob->setManagers(d_func()->m_renderer->nodeManagers());
+            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_updateShaderDataTransformJob;
         }
 
         QVector<Qt3DCore::QAspectJobPtr> frameCleanupJob()
         {
-            static_cast<Render::Renderer *>(d_func()->m_renderer)->m_cleanupJob->setRoot(d_func()->m_renderer->sceneRoot());
-            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::Renderer *>(d_func()->m_renderer)->m_cleanupJob;
+            static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_cleanupJob->setRoot(d_func()->m_renderer->sceneRoot());
+            return QVector<Qt3DCore::QAspectJobPtr>() << static_cast<Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_cleanupJob;
         }
 
         QVector<Qt3DCore::QAspectJobPtr> renderBinJobs()
@@ -130,7 +130,7 @@ namespace Qt3DRender {
                 for (const Qt3DCore::QNodeCreatedChangeBasePtr change : creationChanges)
                     d_func()->createBackendNode(change);
 
-                static_cast<Qt3DRender::Render::Renderer *>(d_func()->m_renderer)->m_renderSceneRoot =
+                static_cast<Qt3DRender::Render::OpenGL::Renderer *>(d_func()->m_renderer)->m_renderSceneRoot =
                         d_func()->m_renderer->nodeManagers()
                         ->lookupResource<Qt3DRender::Render::Entity, Qt3DRender::Render::EntityManager>(root->id());
             }

--- a/tests/benchmarks/render/materialparametergathering/tst_bench_materialparametergathering.cpp
+++ b/tests/benchmarks/render/materialparametergathering/tst_bench_materialparametergathering.cpp
@@ -78,9 +78,9 @@ public:
         return d_func()->m_renderer->nodeManagers();
     }
 
-    Render::MaterialParameterGathererJobPtr materialGathererJob() const
+    Render::OpenGL::MaterialParameterGathererJobPtr materialGathererJob() const
     {
-        Render::MaterialParameterGathererJobPtr job = Render::MaterialParameterGathererJobPtr::create();
+        Render::OpenGL::MaterialParameterGathererJobPtr job = Render::OpenGL::MaterialParameterGathererJobPtr::create();
         job->setNodeManagers(nodeManagers());
         return job;
     }
@@ -124,7 +124,7 @@ private Q_SLOTS:
         QScopedPointer<Qt3DRender::TestAspect> aspect(new Qt3DRender::TestAspect(buildTestScene(2000)));
 
         // WHEN
-        Qt3DRender::Render::MaterialParameterGathererJobPtr gatheringJob = aspect->materialGathererJob();
+        Qt3DRender::Render::OpenGL::MaterialParameterGathererJobPtr gatheringJob = aspect->materialGathererJob();
         gatheringJob->setHandles(aspect->nodeManagers()->materialManager()->activeHandles());
 
         QBENCHMARK {


### PR DESCRIPTION
This will allow to remove the GL prefix on various places and ensure we don't
define twice the same function in the Render namespace somehow.

Change-Id: I5314da1df7fbfd1b6db4412e7bc71231525d9de2