### PR TITLE
Renderer: stop passing buffer type around

### DIFF
--- a/src/render/renderers/opengl/graphicshelpers/submissioncontext.cpp
+++ b/src/render/renderers/opengl/graphicshelpers/submissioncontext.cpp
@@ -1235,7 +1235,7 @@ bool SubmissionContext::setParameters(ShaderParameterPack &parameterPack)
     int ssboIndex = 0;
     for (const BlockToSSBO b : blockToSSBOs) {
         Buffer *cpuBuffer = m_renderer->nodeManagers()->bufferManager()->lookupResource(b.m_bufferID);
-        GLBuffer *ssbo = glBufferForRenderBuffer(cpuBuffer, GLBuffer::ShaderStorageBuffer);
+        GLBuffer *ssbo = glBufferForRenderBuffer(cpuBuffer);
         bindShaderStorageBlock(shader->programId(), b.m_blockIndex, ssboIndex);
         // Needed to avoid conflict where the buffer would already
         // be bound as a VertexArray
@@ -1250,7 +1250,7 @@ bool SubmissionContext::setParameters(ShaderParameterPack &parameterPack)
     int uboIndex = 0;
     for (const BlockToUBO &b : blockToUBOs) {
         Buffer *cpuBuffer = m_renderer->nodeManagers()->bufferManager()->lookupResource(b.m_bufferID);
-        GLBuffer *ubo = glBufferForRenderBuffer(cpuBuffer, GLBuffer::UniformBuffer);
+        GLBuffer *ubo = glBufferForRenderBuffer(cpuBuffer);
         bindUniformBlock(shader->programId(), b.m_blockIndex, uboIndex);
         // Needed to avoid conflict where the buffer would already
         // be bound as a VertexArray
@@ -1363,7 +1363,7 @@ void SubmissionContext::specifyAttribute(const Attribute *attribute,
 
 void SubmissionContext::specifyIndices(Buffer *buffer)
 {
-    GLBuffer *buf = glBufferForRenderBuffer(buffer, GLBuffer::IndexBuffer);
+    GLBuffer *buf = glBufferForRenderBuffer(buffer);
     if (!bindGLBuffer(buf, GLBuffer::IndexBuffer))
         qCWarning(Backend) << Q_FUNC_INFO << "binding index buffer failed";
 
@@ -1411,23 +1411,20 @@ bool SubmissionContext::hasGLBufferForBuffer(Buffer *buffer)
     return (it != m_renderBufferHash.end());
 }
 
-GLBuffer *SubmissionContext::glBufferForRenderBuffer(Buffer *buf, GLBuffer::Type type)
+GLBuffer *SubmissionContext::glBufferForRenderBuffer(Buffer *buf)
 {
     if (!m_renderBufferHash.contains(buf->peerId()))
-        m_renderBufferHash.insert(buf->peerId(), createGLBufferFor(buf, type));
+        m_renderBufferHash.insert(buf->peerId(), createGLBufferFor(buf));
     return m_renderer->glResourceManagers()->glBufferManager()->data(m_renderBufferHash.value(buf->peerId()));
 }
 
-HGLBuffer SubmissionContext::createGLBufferFor(Buffer *buffer, GLBuffer::Type type)
+HGLBuffer SubmissionContext::createGLBufferFor(Buffer *buffer)
 {
     GLBuffer *b = m_renderer->glResourceManagers()->glBufferManager()->getOrCreateResource(buffer->peerId());
     //    b.setUsagePattern(static_cast<QOpenGLBuffer::UsagePattern>(buffer->usage()));
     Q_ASSERT(b);
     if (!b->create(this))
         qCWarning(Render::Io) << Q_FUNC_INFO << "buffer creation failed";
-
-    if (!bindGLBuffer(b, type))
-        qCWarning(Render::Io) << Q_FUNC_INFO << "buffer binding failed";
 
     return m_renderer->glResourceManagers()->glBufferManager()->lookupHandle(buffer->peerId());
 }

--- a/src/render/renderers/opengl/graphicshelpers/submissioncontext_p.h
+++ b/src/render/renderers/opengl/graphicshelpers/submissioncontext_p.h
@@ -140,7 +140,7 @@ public:
     QByteArray downloadBufferContent(Buffer *buffer);
     void releaseBuffer(Qt3DCore::QNodeId bufferId);
     bool hasGLBufferForBuffer(Buffer *buffer);
-    GLBuffer *glBufferForRenderBuffer(Buffer *buf, GLBuffer::Type type);
+    GLBuffer *glBufferForRenderBuffer(Buffer *buf);
 
     // Parameters
     bool setParameters(ShaderParameterPack &parameterPack);
@@ -179,7 +179,7 @@ private:
 
 
     // Buffers
-    HGLBuffer createGLBufferFor(Buffer *buffer, GLBuffer::Type type);
+    HGLBuffer createGLBufferFor(Buffer *buffer);
     void uploadDataToGLBuffer(Buffer *buffer, GLBuffer *b, bool releaseBuffer = false);
     QByteArray downloadDataFromGLBuffer(Buffer *buffer, GLBuffer *b);
     bool bindGLBuffer(GLBuffer *buffer, GLBuffer::Type type);

--- a/src/render/renderers/opengl/renderer/renderer.cpp
+++ b/src/render/renderers/opengl/renderer/renderer.cpp
@@ -1159,7 +1159,7 @@ void Renderer::updateGLResources()
             // Forces creation if it doesn't exit
             // Also note the binding point doesn't really matter here, we just upload data
             if (!m_submissionContext->hasGLBufferForBuffer(buffer))
-                m_submissionContext->glBufferForRenderBuffer(buffer, GLBuffer::ArrayBuffer);
+                m_submissionContext->glBufferForRenderBuffer(buffer);
             // Update the glBuffer data
             m_submissionContext->updateBuffer(buffer);
             buffer->unsetDirty();
@@ -1748,7 +1748,7 @@ void Renderer::performDraw(RenderCommand *command)
         }
 
         // Get GLBuffer from Buffer;
-        GLBuffer *indirectDrawGLBuffer = m_submissionContext->glBufferForRenderBuffer(indirectDrawBuffer, GLBuffer::DrawIndirectBuffer);
+        GLBuffer *indirectDrawGLBuffer = m_submissionContext->glBufferForRenderBuffer(indirectDrawBuffer);
         if (Q_UNLIKELY(indirectDrawGLBuffer == nullptr)) {
             qWarning() << "Invalid Indirect Draw Buffer - failed to retrieve GLBuffer";
             return;


### PR DESCRIPTION
It only make sense to pass it for the bind call

Change-Id: I8f0cd204c109b2ff24f4eec320811b6cecaf3873